### PR TITLE
Search for the whole building name not for every word

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -56,7 +56,7 @@ class Room < ApplicationRecord
       tsearch: {
         dictionary: "english",
         prefix: true,
-        any_word: true,
+        any_word: false,
 
       }
     }


### PR DESCRIPTION
Added "any_word: false," to the rooms model