### PR TITLE
Fix error uninitialized constant

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -7,6 +7,7 @@ include ActionView::RecordIdentifier
   before_action :set_filters_list, only: [:index]
 
   helper_method :sort_direction
+  include ApplicationHelper 
 
   def index
 


### PR DESCRIPTION
I got the error "uninitialized constant RoomsController::ROOM_CHARACTERISTIC_NAME" in the main branch on my local computer. It happens when a checkbox in filters is checked. 
I don't have this error in the branch where I created the ROOM_CHARACTERISTIC_NAME constant: just verified.

I believe this is why the staging server gives "We're sorry, but something went wrong" if you check a filters' checkbox. 

Please verify that on the server and consider approving this pull request.