### PR TITLE
Function: sort by capacity without sidebar toggle

### DIFF
--- a/app/packs/controllers/autosubmit_controller.js
+++ b/app/packs/controllers/autosubmit_controller.js
@@ -22,6 +22,15 @@ export default class extends Controller {
     }, 0)
   }
 
+  sortCapacity() {
+    clearTimeout(this.timeout)
+
+    this.timeout = setTimeout(() => {
+      this.statusTarget.textContent = 'Updating...'
+      Turbo.navigator.submitForm(this.formTarget)
+    }, 0)
+  }
+
   change(event) {
     event.preventDefault()
     Turbo.navigator.submitForm(this.formTarget)

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -165,7 +165,7 @@
             <div class="flex justify-end items-center">
               <label for="direction" class="border-0 h-px -m-px overflow-hidden p-0 absolute w-px">Sort by capacity</label>
               <%= select_tag "direction", options_for_select([["Low to High", "asc"], ["High to Low", "desc"]]), include_blank: "Sort Room Capacity", class: "rounded-md sm:text-sm ml-2",
-              :"data-action" => "change->autosubmit#search" %>
+              :"data-action" => "change->autosubmit#sortCapacity" %>
             </div>
           </div>
           <div class="">


### PR DESCRIPTION
Created a function in autosubmit_controller.js to address sorting by capacity. It should not toggle the sidebar, like all other filters.
```
sortCapacity() {
    clearTimeout(this.timeout)
    this.timeout = setTimeout(() => {
      this.statusTarget.textContent = 'Updating...'
      Turbo.navigator.submitForm(this.formTarget)
    }, 0)
  }
```
```
checkboxSubmit() {
    clearTimeout(this.timeout)
    this.timeout = setTimeout(() => {
      this.statusTarget.textContent = 'Updating...'
      Turbo.navigator.submitForm(this.formTarget)
      this.sidebarTarget.classList.toggle('-translate-x-full')
    }, 0)
  }
```