### PR TITLE
Rediect to Find a Room page if user singed in

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -18,8 +18,14 @@
         <p class="mt-4 max-w-xl md:max-w-3xl mx-auto text-xl text-gray-600">
           MClassrooms provides an intuitive, accessible interface to find the room you are looking for. Whether you are an instructor searching for a classroom with the technologies to meet your pedegogy, a student trying to find their way to class, or a staff member looking to schedule a room; MClassrooms has your back.
         </p>
-        <%= button_to user_saml_omniauth_authorize_path, data: {turbo: "false"} do %>
-          <div class="mt-10 inline-block w-full bg-gray-900 border border-transparent rounded-md py-3 px-8 font-medium text-white hover:bg-gray-800 sm:w-auto mb-10 sm:mb-0 href="#">Log In To Find A Room!</div>
+        <% if current_user %>
+          <%= button_to rooms_path, method: :get do %>
+            <div class="mt-10 inline-block w-full bg-gray-900 border border-transparent rounded-md py-3 px-8 font-medium text-white hover:bg-gray-800 sm:w-auto mb-10 sm:mb-0 href="#">Log In To Find A Room!</div>
+          <% end %>
+        <% else %>
+          <%= button_to user_saml_omniauth_authorize_path, data: {turbo: "false"} do %>
+            <div class="mt-10 inline-block w-full bg-gray-900 border border-transparent rounded-md py-3 px-8 font-medium text-white hover:bg-gray-800 sm:w-auto mb-10 sm:mb-0 href="#">Log In To Find A Room!</div>
+          <% end %>
         <% end %>
       </div>
     </section>


### PR DESCRIPTION
A bug: since we enabled the Home (landing page) for admins after they log in, the button [Log in to find a room] redirected current users to their profile.
A fix: if there is a current user the button should redirect to the Find a Room page.