### PR TITLE
Bugfix/raic 48 browser back button issue

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -34,13 +34,17 @@ include ActionView::RecordIdentifier
     
     @pagy, @rooms = pagy(@rooms)
 
-    unless params[:query].nil?
-      render turbo_stream: turbo_stream.replace(
-        :roomListing,
-        partial: "rooms/listing"
-      )
-    end
+    # unless params[:query].nil?
+    #   render turbo_stream: turbo_stream.replace(
+    #     :roomListing,
+    #     partial: "rooms/listing"
+    #   )
+    # end
 
+  end
+
+  def clear
+    
   end
 
   # GET /rooms/1

--- a/app/packs/controllers/autosubmit_controller.js
+++ b/app/packs/controllers/autosubmit_controller.js
@@ -60,8 +60,10 @@ export default class extends Controller {
   }
 
   clearFilters() {
-    console.log("clear")
-    this.formTarget.reset()
-    Turbo.navigator.submitForm(this.formTarget)
+    var url = window.location.pathname
+    // console.log(url)
+    Turbo.visit(url)
+    // this.formTarget.reset()
+    // Turbo.navigator.submitForm(this.formTarget)
   }
 }

--- a/app/packs/controllers/autosubmit_controller.js
+++ b/app/packs/controllers/autosubmit_controller.js
@@ -60,6 +60,7 @@ export default class extends Controller {
   }
 
   clearFilters() {
+    console.log("clear")
     this.formTarget.reset()
     Turbo.navigator.submitForm(this.formTarget)
   }

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -29,7 +29,4 @@ class RoomPolicy < ApplicationPolicy
     edit?
   end
 
-  def get_current_url?
-    true
-  end
 end

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -28,4 +28,8 @@ class RoomPolicy < ApplicationPolicy
   def update?
     edit?
   end
+
+  def get_current_url?
+    true
+  end
 end

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -46,13 +46,13 @@
             <hr>
             <div class="px-1">
               <label for="building_name">Search Building Names</label>
-              <%= form.text_field :query, class: "block rounded-none rounded-l-md sm:text-sm border-gray-300", :placeholder => 'ex. "East Hall"', value: params[:query],  :"data-action" => "input->autosubmit#search", :"data-autosubmit-target" => "building_name" %>
+              <%= form.text_field :query, class: "block rounded-none rounded-l-md sm:text-sm border-gray-300", :placeholder => 'ex. "East Hall"', value: params[:query], :"data-action" => "input->autosubmit#search", :"data-autosubmit-target" => "building_name" %>
             </div>
             <br>
             <hr>
             <div class="px-1 pb-2">
               <label for="classroom_name">Search Classroom Name</label>
-              <%= form.text_field :classroom_name, class: 'block rounded-none rounded-l-md sm:text-sm border-gray-300', data: { action: "input->autosubmit#search" }, :placeholder => 'ex. "USB4153"' %>
+              <%= form.text_field :classroom_name, class: 'block rounded-none rounded-l-md sm:text-sm border-gray-300', data: { action: "input->autosubmit#search" }, :placeholder => 'ex. "USB4153"', value: params[:classroom_name] %>
             </div>
             <br>
             <hr>
@@ -61,12 +61,19 @@
               <div class="flex mt-2">
                 <div class="w-1/2 ml-2 mr-2">
                   <label class="block text-sm font-medium text-gray-700" for="min_capacity">Min</label>
-                  <%= number_field_tag 'min_capacity', nil, min: 1, value: 0, :"data-autosubmit-target" => "min_capacity", data: { action: "input->autosubmit#capacitySubmit" }, class: 'w-full block rounded sm:text-sm border-gray-300' %>
-                  
+                  <% if params[:min_capacity].present? %>
+                    <%= number_field_tag 'min_capacity', nil, min: 1, value: params[:min_capacity], :"data-autosubmit-target" => "min_capacity", data: { action: "input->autosubmit#capacitySubmit" }, class: 'w-full block rounded sm:text-sm border-gray-300' %>
+                  <% else %>
+                    <%= number_field_tag 'min_capacity', nil, min: 1, value: 0, :"data-autosubmit-target" => "min_capacity", data: { action: "input->autosubmit#capacitySubmit" }, class: 'w-full block rounded sm:text-sm border-gray-300' %>
+                  <% end %>
                 </div>
                 <div class="ml-1 mr-2 w-1/2">
                   <label class="block text-sm font-medium text-gray-700" for="max_capacity">Max</label>
-                  <%= number_field_tag 'max_capacity', nil, max: 600, value: 600, :"data-autosubmit-target" => "max_capacity", data: { action: "input->autosubmit#capacitySubmit"}, class: 'w-full block rounded sm:text-sm border-gray-300' %>
+                  <% if params[:max_capacity].present? %>
+                    <%= number_field_tag 'max_capacity', nil, max: 600, value: params[:max_capacity], :"data-autosubmit-target" => "max_capacity", data: { action: "input->autosubmit#capacitySubmit"}, class: 'w-full block rounded sm:text-sm border-gray-300' %>
+                  <% else %>
+                    <%= number_field_tag 'max_capacity', nil, max: 600, value: 600, :"data-autosubmit-target" => "max_capacity", data: { action: "input->autosubmit#capacitySubmit"}, class: 'w-full block rounded sm:text-sm border-gray-300' %>
+                  <% end %>
                 </div>
               </div>
               <span class="capacity-error--hide text-red-700 text-sm mt-2 -mb-2" data-autosubmit-target="capacity_error">

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -39,14 +39,14 @@
           <div class="pl-1 bg-gray-50 shadow border">
             <div class="px-1">
               <label for="school_or_college_name">Select a School/College</label>
-                <%= select_tag "school_or_college_name", options_for_select(@schools, " "), include_blank: "Select ...", class: "block rounded-none rounded-l-md text-xs border-gray-300",
+                <%= select_tag "school_or_college_name", options_for_select(@schools, selected: params[:school_or_college_name]), include_blank: "Select ...", class: "block rounded-none rounded-l-md text-xs border-gray-300",
                           :"data-action" => "change->autosubmit#search" %>
             </div>
             <br>
             <hr>
             <div class="px-1">
               <label for="building_name">Search Building Names</label>
-              <%= form.text_field :query, class: "block rounded-none rounded-l-md sm:text-sm border-gray-300", :placeholder => 'ex. "East Hall"', :"data-action" => "input->autosubmit#search", :"data-autosubmit-target" => "building_name" %>
+              <%= form.text_field :query, class: "block rounded-none rounded-l-md sm:text-sm border-gray-300", :placeholder => 'ex. "East Hall"', value: params[:query],  :"data-action" => "input->autosubmit#search", :"data-autosubmit-target" => "building_name" %>
             </div>
             <br>
             <hr>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -121,7 +121,7 @@
     </div>
   </div>
   <div class="py-2 mb-20">
-    <%= link_to 'Back', rooms_path, class: "hover:underline text-blue-800", data: {turbo: "false"} %>
+    <%= link_to 'Back', :back, class: "hover:underline text-blue-800", data: {turbo: "false"} %>
     <% if user_signed_in? && policy(Room).edit? %>
       |
       <%= link_to 'Edit', edit_room_path(@room), class: "hover:underline text-blue-800", data: {turbo: "false"} %>


### PR DESCRIPTION
In the rooms_controller: comment the part where turbo-frame (id=roomListing) is rendered when search parameters are changing.
In autosubmit_controller.js: change CleatFilters function - reload the page.
In the rooms index page: keep selected filters' data after the page reloaded.
In the room show page: The Back button goes to the browser's back, not to the rooms index view.