### PR TITLE
Lra 259 mclassrooms hide certain room details when links files do not exist

### DIFF
--- a/app/packs/stylesheets/search.sass
+++ b/app/packs/stylesheets/search.sass
@@ -1,9 +1,9 @@
 .search-by-building-name
-  @apply shadow-sm h-10 w-full  flex flex-row border-gray-300 border-l border-t border-b 
+  @apply shadow-sm h-10 w-full  flex flex-row border-gray-300 border-l border-t border-b
   &:focus
     @apply outline-none ring-2 ring-blue-500 border-transparent
   input
-    @apply block border-none h-full 
+    @apply block border-none h-full
   .submit-search
     @apply bg-blue-300 rounded-r-md w-24 text-blue-800 text-lg font-medium border border-gray-300 h-10
 
@@ -19,7 +19,7 @@
 
 .characteristics-list
   @apply mt-4 space-y-4 mr-6
-  
+
 .characteristic-checkbox
   @apply -m-2 px-2 py-1 flex items-center rounded text-blue-700 transition ease-in-out duration-150 border border-blue-300 bg-blue-100
   svg
@@ -36,19 +36,19 @@
   @apply flex justify-items-stretch flex-wrap  space-y-2 max-w-full lg:max-w-xl
 
 .rounded-checkbox
-  @apply justify-center align-middle mt-2 mx-1 whitespace-nowrap truncate  px-2 py-1 flex items-center rounded-2xl text-sm text-blue-700 transition ease-in-out duration-150 border border-blue-400 bg-blue-100 
+  @apply justify-center align-middle mt-2 mx-1 whitespace-nowrap truncate  px-2 py-1 flex items-center rounded-2xl text-sm text-blue-700 transition ease-in-out duration-150 border border-blue-400 bg-blue-100
   label
-    @apply flex flex-row 
+    @apply flex flex-row
     span
       @apply ml-1
   svg
-    @apply h-3 w-3 
+    @apply h-3 w-3
   &:hover
     @apply bg-blue-200
 
 .check-box
   input[type="checkbox"]:checked + label
-    @apply bg-blue-500 text-blue-100  
+    @apply bg-blue-500 text-blue-100
     svg
       @apply text-blue-100
     &:hover
@@ -58,23 +58,21 @@
   @apply text-base font-bold tracking-wide text-gray-900 uppercase border-b border-gray-400 mt-6 pb-1
 
 .filters-dropdown
-  @apply min-w-full transform shadow-lg border-b absolute inset-x-0 transform shadow-lg pb-20 mt-4 bg-gray-50 
+  @apply min-w-full transform shadow-lg border-b absolute inset-x-0 transform shadow-lg pb-20 mt-4 bg-gray-50
 
 .filters-inner
   @apply relative inset-0 flex
 
 .view-all-link
   // @apply pb-8 pr-8 text-sm font-medium mt-6 sm:mt-auto
-  @apply bg-green-400 relative bottom-0 right-0 
+  @apply bg-green-400 relative bottom-0 right-0
   a
     @apply text-blue-600 p-2
     &:hover
       @apply text-blue-800 bg-blue-100 rounded-lg
 
 .link-to-all-classrooms
-  @apply absolute bottom-0 right-6 text-blue-600 underline 
-
-
+  @apply absolute bottom-0 right-6 text-blue-600 underline
 
 .choices
   @apply  text-left
@@ -107,13 +105,13 @@
   @apply w-full mx-auto  pr-8 h-auto w-auto
 
 #slider
-  @apply h-2 mt-12 z-0 
+  @apply h-2 mt-12 z-0
   @screen xl
     @apply ml-2 mr-4
   .noUi-connect
-    @apply bg-blue-700 h-2 z-0 
+    @apply bg-blue-700 h-2 z-0
   .noUi-base
-    @apply bg-blue-400 z-0 
+    @apply bg-blue-400 z-0
   .noUi-handle
     @apply bg-yellow-500 rounded-full h-6 w-6 border-2 border-blue-700 z-0 -mt-1
     &:before
@@ -133,7 +131,7 @@
   @apply relative w-screen max-w-xs right-0
 
 .h-highlights
-  @apply  grid grid-cols-3 gap-x-1 gap-y-2 px-2 
+  @apply  grid grid-cols-3 gap-x-1 gap-y-2 px-2
   @screen md
     @apply grid-cols-5
   @screen lg
@@ -155,15 +153,31 @@
   @screen lg
     @apply text-sm
     svg
-      @apply h-4 w-4 
-  @screen xl 
+      @apply h-4 w-4
+  @screen xl
     @apply  mx-1
     svg
       @apply h-3 w-3 mr-1
   &:hover
     @apply underline
-    
 
+.h-no-highlight-item
+  @apply inline-flex text-sm text-black whitespace-nowrap items-center font-semibold mx-2
+  svg
+    @apply h-5 w-5 mr-1
+
+  @screen md
+    @apply text-base
+    svg
+      @apply h-5 w-5
+  @screen lg
+    @apply text-sm
+    svg
+      @apply h-4 w-4
+  @screen xl
+    @apply  mx-1
+    svg
+      @apply h-3 w-3 mr-1
 
 .classroom-row-dropdown-toggle
   @apply text-sm text-gray-600 font-light inline-flex
@@ -179,32 +193,29 @@
   @apply  pt-2 text-black
 
 .classroom-row-dropdown-features-section
-  @apply w-full max-w-2xl 
-  @screen lg  
-    
+  @apply w-full max-w-2xl
+  @screen lg
 
-.classroom-row-dropdown-features-group 
+.classroom-row-dropdown-features-group
   hr
     @apply flex-1 border-t border-blue-600 mt-1 mx-2
-  @screen md 
+  @screen md
     @apply mr-4
 
-
-    
 .classroom-row-dropdown-top-matter
-  @apply w-full 
+  @apply w-full
 
 .classroom-row-dropdown-features
   @apply  grid grid-cols-4  grid-flow-row mt-2
-  @screen md 
-    @apply grid-cols-3 
+  @screen md
+    @apply grid-cols-3
   li
     @apply whitespace-nowrap truncate
   svg
     @apply h-4 w-4
 
 .classroom-row-dropdown-feature
-  @apply flex items-start truncate mt-1 ml-1 whitespace-nowrap items-center 
+  @apply flex items-start truncate mt-1 ml-1 whitespace-nowrap items-center
 
 .classroom-row-contact-icon
   @apply flex items-center justify-center h-5 w-5 rounded-md
@@ -213,13 +224,12 @@
 
 .classroom-row-contact-items
   @apply truncate text-left w-full mt-4
-  
 
 .classroom-row-contact-item
   @apply bg-white rounded py-4 pr-6 pl-2 truncate mt-2
 
   h5
-    @apply  truncate text-lg leading-tight -mt-1 
+    @apply  truncate text-lg leading-tight -mt-1
   ul
     @apply leading-tight
     li

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -88,34 +88,42 @@
         <%= @room.instructional_seating_count %>
       </div>
       <div class="grid grid-cols-3 text-sm font-medium">
-
-        <%= link_to "https://csprod.dsc.umich.edu/services/facilitycalendar?facilityid=#{@room.facility_code_heprod }", target: "_blank" do %>
-          <div class="h-layout h-highlight-item">
-            <%= svg("calendar_days")  %>
-            <span>Room Availability</span>
-          </div>
-        <% end %>
-        <% if @room.room_layout.representable? %>
-          <%= link_to room_layout(@room), target: "_blank" do %>
+        <div>
+          <%= link_to "https://csprod.dsc.umich.edu/services/facilitycalendar?facilityid=#{@room.facility_code_heprod }", target: "_blank" do %>
             <div class="h-layout h-highlight-item">
-              <%= svg("chair") %>
-              <span>Room Layout</span>
-            </div>
-          <% end %> 
-        <% end %>
-        <% if false %>
-          <%= link_to "#", target: "_blank" do %>
-            <div class="h-layout h-highlight-item">
-              <%= svg("layer_group") %>
-              <span>Floor <%= @room.floor.gsub(/[0]/, '') %> Map  </span>
+              <%= svg("calendar_days")  %>
+              <span>Room Availability</span>
             </div>
           <% end %>
-        <% else %>
-          <div class="h-layout h-no-highlight-item">
-            <%= svg("layer_group") %>
-            <span>Floor <%= @room.floor.gsub(/[0]/, '') %></span>
-          </div>
-        <% end %>
+        </div>
+        <div>
+          <% if @room.room_layout.representable? %>
+            <%= link_to room_layout(@room), target: "_blank" do %>
+              <div class="h-layout h-highlight-item">
+                <%= svg("chair") %>
+                <span>Room Layout</span>
+              </div>
+            <% end %>
+          <% else %>
+          <div>skip</div>
+
+          <% end %>
+        </div>
+        <div>
+          <% if false %>
+            <%= link_to "#", target: "_blank" do %>
+              <div class="h-layout h-highlight-item">
+                <%= svg("layer_group") %>
+                <span>Floor <%= @room.floor.gsub(/[0]/, '') %> Map  </span>
+              </div>
+            <% end %>
+          <% else %>
+            <div class="h-layout h-no-highlight-item">
+              <%= svg("layer_group") %>
+              <span>Floor <%= @room.floor.gsub(/[0]/, '') %></span>
+            </div>
+          <% end %>
+        </div>
       </div>
       <%= render 'characteristics', room: @room%>
     </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -95,18 +95,27 @@
             <span>Room Availability</span>
           </div>
         <% end %>
-        <%= link_to room_layout(@room), target: "_blank" do %>
-          <div class="h-layout h-highlight-item">
-            <%= svg("chair") %>
-            <span>Room Layout</span>
-          </div>
-        <% end %> 
-        <%= link_to "#", target: "_blank" do %>
-          <div class="h-layout h-highlight-item">
+        <% if @room.room_layout.representable? %>
+          <%= link_to room_layout(@room), target: "_blank" do %>
+            <div class="h-layout h-highlight-item">
+              <%= svg("chair") %>
+              <span>Room Layout</span>
+            </div>
+          <% end %> 
+        <% end %>
+        <% if false %>
+          <%= link_to "#", target: "_blank" do %>
+            <div class="h-layout h-highlight-item">
+              <%= svg("layer_group") %>
+              <span>Floor <%= @room.floor.gsub(/[0]/, '') %> Map  </span>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="h-layout h-no-highlight-item">
             <%= svg("layer_group") %>
-            <span>Floor <%= @room.floor.gsub(/[0]/, '') %> Map  </span>
+            <span>Floor <%= @room.floor.gsub(/[0]/, '') %></span>
           </div>
-        <% end %> 
+        <% end %>
       </div>
       <%= render 'characteristics', room: @room%>
     </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -120,9 +120,9 @@
   </div>
 <% end %>
 
-<div class="container p-2 rounded-lg shadow-lg text-xl mb-20 -mt-16 bg-gray-50">Notes:
+<div class="container p-2 rounded-lg shadow-lg text-xl mb-20 -mt-16 bg-gray-50">
   <% if session["user_admin"] %>
-    <div class="mb-20">
+    <div class="mb-20">Notes:
       <% if user_signed_in? %>
         <%= render partial: "notes/form", locals: { note: Note.new, noteable: @room } %>
       <% else %>
@@ -135,14 +135,16 @@
       <% end %>
     </div>
   <% else %>
-    <div>
-      <% @room.notes.each do |note| %>
-        <hr class= "flex-1 border-t border-blue-600 mt-1 mb-2 m-2">
-        <div class="text-sm pb-1">
-          <%= note.updated_at.strftime('%m/%d/%Y') %>
-          <%= note.body  %>
-        </div>
-      <% end %>
-    </div>
+    <% if @room.notes.present? %>
+      <div>Notes:
+        <% @room.notes.each do |note| %>
+          <hr class= "flex-1 border-t border-blue-600 mt-1 mb-2 m-2">
+          <div class="text-sm pb-1">
+            <%= note.updated_at.strftime('%m/%d/%Y') %>
+            <%= note.body  %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -82,7 +82,7 @@
   </div>
 
   <div>
-    <div class="container grid p-2 text-xl border-t-2 border-gray-100">Details
+    <div class="container p-2 text-xl border-t-2 border-gray-100">Details
 
       <div class="text-lg">Instructional seating count:
         <%= @room.instructional_seating_count %>
@@ -104,9 +104,6 @@
                 <span>Room Layout</span>
               </div>
             <% end %>
-          <% else %>
-          <div>skip</div>
-
           <% end %>
         </div>
         <div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,59 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-locations = ['index_page', 'rooms_page']
-existing_locations = Announcement.all.pluck(:location)
+# The following was run on the staging server manualy
+# Put here to keep records of these updates
 
-locations.each do |location|
-  unless existing_locations.include?(location)
-    Announcement.create!(location: location)
-  end
-end
+# locations = ['index_page', 'rooms_page']
+# existing_locations = Announcement.all.pluck(:location)
+
+# locations.each do |location|
+#   unless existing_locations.include?(location)
+#     Announcement.create!(location: location)
+#   end
+# end
+
+# Building.find_by(bldrecnbr: 1000151).update(nick_name: "UMMA")
+# Building.find_by(bldrecnbr: 1005046).update(nick_name: "USB")
+# Building.find_by(bldrecnbr: 1000165).update(nick_name: "WEIS")
+# Building.find_by(bldrecnbr: 1000162).update(nick_name: "DENT")
+# Building.find_by(bldrecnbr: 1005235).update(nick_name: "LSSH")
+# Building.find_by(bldrecnbr: 1005177).update(nick_name: "NQ")
+# Building.find_by(bldrecnbr: 1000440).update(nick_name: "SM")
+# Building.find_by(bldrecnbr: 1000054).update(nick_name: "EQ")
+# Building.find_by(bldrecnbr: 1000234).update(nick_name: "SPH")
+# Building.find_by(bldrecnbr: 1000333).update(nick_name: "400NI")
+# Building.find_by(bldrecnbr: 1005101).update(nick_name: "WEILL")
+# Building.find_by(bldrecnbr: 1005370).update(nick_name: "BLAU")
+# Building.find_by(bldrecnbr: 1000211).update(nick_name: "SKB")
+# Building.find_by(bldrecnbr: 1000216).update(nick_name: "TAP")
+# Building.find_by(bldrecnbr: 1000207).update(nick_name: "MLB")
+# Building.find_by(bldrecnbr: 1005451).update(nick_name: "CCCB")
+# Building.find_by(bldrecnbr: 1005188).update(nick_name: "R-BUS")
+# Building.find_by(bldrecnbr: 1000158).update(nick_name: "CHEM")
+# Building.find_by(bldrecnbr: 1000152).update(nick_name: "AH")
+# Building.find_by(bldrecnbr: 1000154).update(nick_name: "LORCH")
+# Building.find_by(bldrecnbr: 1000059).update(nick_name: "ALH")
+# Building.find_by(bldrecnbr: 1000179).update(nick_name: "HUTCH")
+# Building.find_by(bldrecnbr: 1000197).update(nick_name: "MH")
+# Building.find_by(bldrecnbr: 1000188).update(nick_name: "NUB")
+# Building.find_by(bldrecnbr: 1000221).update(nick_name: "SEB")
+# Building.find_by(bldrecnbr: 1000206).update(nick_name: "AH")
+# Building.find_by(bldrecnbr: 1000204).update(nick_name: "SPH")
+# Building.find_by(bldrecnbr: 1005059).update(nick_name: "WDC")
+# Building.find_by(bldrecnbr: 1005347).update(nick_name: "426NI")
+# Building.find_by(bldrecnbr: 1000184).update(nick_name: "LLIBS")
+# Building.find_by(bldrecnbr: 1005179).update(nick_name: "STB")
+# Building.find_by(bldrecnbr: 1000219).update(nick_name: "SSWB")
+# Building.find_by(bldrecnbr: 1000150).update(nick_name: "LSA")
+# Building.find_by(bldrecnbr: 1000189).update(nick_name: "DANA")
+# Building.find_by(bldrecnbr: 1000175).update(nick_name: "HH")
+# Building.find_by(bldrecnbr: 1000166).update(nick_name: "EH")
+# Building.find_by(bldrecnbr: 1000890).update(nick_name: "PERRY")
+# Building.find_by(bldrecnbr: 1005224).update(nick_name: "STAMPS")
+# Building.find_by(bldrecnbr: 1000155).update(nick_name: "BMT")
+# Building.find_by(bldrecnbr: 1000167).update(nick_name: "WH")
+# Building.find_by(bldrecnbr: 1005169).update(nick_name: "BSB")
+# Building.find_by(bldrecnbr: 1005047).update(nick_name: "PALM")
+# Building.find_by(bldrecnbr: 1000208).update(nick_name: "RAND")
+

--- a/lib/buildings_api.rb
+++ b/lib/buildings_api.rb
@@ -118,7 +118,7 @@ class BuildingsApi
 
   def update_building(row)
     building = Building.find_by(bldrecnbr: row['BuildingRecordNumber'])
-    if building.update(bldrecnbr: row['BuildingRecordNumber'], name: row['BuildingLongDescription'], nick_name: row['BuildingLongDescription'], abbreviation: row['BuildingShortDescription'], 
+    if building.update(bldrecnbr: row['BuildingRecordNumber'], name: row['BuildingLongDescription'], abbreviation: row['BuildingShortDescription'], 
           address: " #{row['BuildingStreetNumber']}  #{row['BuildingStreetDirection']}  #{row['BuildingStreetName']}".strip.gsub(/\s+/, " "), 
           city: row['BuildingCity'], state: row['BuildingState'], zip: row['BuildingPostal'], country: 'usa again', 
           campus_record_id: CampusRecord.find_by(campus_cd: row['BuildingCampusCode']).id)
@@ -129,7 +129,7 @@ class BuildingsApi
   end
 
   def create_building(row)
-    building = Building.new(bldrecnbr: row['BuildingRecordNumber'], name: row['BuildingLongDescription'], nick_name: row['BuildingLongDescription'], abbreviation: row['BuildingShortDescription'], 
+    building = Building.new(bldrecnbr: row['BuildingRecordNumber'], name: row['BuildingLongDescription'], abbreviation: row['BuildingShortDescription'], 
         address: " #{row['BuildingStreetNumber']}  #{row['BuildingStreetDirection']}  #{row['BuildingStreetName']}".strip.gsub(/\s+/, " "), 
         city: row['BuildingCity'], state: row['BuildingState'], zip: row['BuildingPostal'], country: 'USA',
         campus_record_id: CampusRecord.find_by(campus_cd: row['BuildingCampusCode']).id)


### PR DESCRIPTION
Added .h-no-highlight-item to search.sass to display floor's number without a link if a room had no floor map. (other changes in the search.sass are format fixes done by VSCode).

In the Room show view hide links if attached files are not present (room_layout);
I don't know how to check if a floor map exists, so for now the flor maps check is [<% if false %>];
remove label "Notes" for users, if there are no notes.

To the seed file added updates for buildings nick_names to keep it. Changes were done in the server's database manually. 
Remove updating the building.nick_name filed from BuildingAPI