### PR TITLE
remove duplicated anchors

### DIFF
--- a/app/views/pages/room_filters_glossary.erb
+++ b/app/views/pages/room_filters_glossary.erb
@@ -13,8 +13,14 @@
     <% end  %>
   </div>
   <div>
+    <% prev_cat = "" %> 
     <% @all_characteristics_array.sort.each do |category, list| %>
-      <div class="mb-2" id="<%= category[0] %>"><a href="<%= category[0] %>" style="display: none;"><%= category[0] %></a>
+      <% cat = category[0] %>
+      <div class="mb-2">
+        <% if cat != prev_cat %>
+          <a href="<%= cat %>" style="display: none;"><%= cat %></a>
+          <% prev_cat = cat %>
+        <% end %>
         <h2><%= category %></h2>
         <ul class="ml-4 text-base">
           <% list.each do |filter, descr| %>


### PR DESCRIPTION
Maria's accessibility test found another problem on the Room Filters Glossary page.

href anchors for categories are created in a loop that takes the first letter of a category's name to create an anchor.
If two categories start with the same letter - two anchors with the same letter were created. That was wrong.
To fix it I have to compare the current category's anchor with a previous one.
