### PR TITLE
Lra 279 mclassroom m community access based on rails env

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -74,13 +74,25 @@ def set_user
   if @user
     admin = false
     membership = []
-    access_groups = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
+    if Rails.env.production?
+      access_groups = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
+    elsif Rails.env.staging?
+      access_groups = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
+    elsif Rails.env.development?
+      access_groups = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
+    end
     access_groups.each do |group|
       if  LdapLookup.is_member_of_group?(@user.uniqname, group)
         membership.append(group)
       end
     end
-    if membership.include?('mi-classrooms-admin')
+    if Rails.env.production? && membership.include?('mi-classrooms-admin')
+      admin = true
+    end
+    if Rails.env.staging? && membership.include?('mi-classrooms-admin-staging')
+      admin = true
+    end
+    if Rails.env.development? && membership.include?('mi-classrooms-admin-staging')
       admin = true
     end
     session[:user_memberships] = membership

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -74,12 +74,9 @@ def set_user
   if @user
     admin = false
     membership = []
+    access_groups = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
     if Rails.env.production?
       access_groups = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
-    elsif Rails.env.staging?
-      access_groups = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
-    elsif Rails.env.development?
-      access_groups = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
     end
     access_groups.each do |group|
       if  LdapLookup.is_member_of_group?(@user.uniqname, group)

--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -7,13 +7,11 @@ class AnnouncementPolicy < ApplicationPolicy
   end
 
   def index?
-    # true
-    user_in_non_admin_group?
+    user.admin
   end
 
   def show?
-    # true
-    user_in_non_admin_group?
+    user.admin
   end  
 
   def edit?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -37,7 +37,13 @@ class ApplicationPolicy
   end
 
   def user_in_non_admin_group?
-    @non_admin_group = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
+    if Rails.env.production?
+      @non_admin_group = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
+    elsif Rails.env.staging?
+      @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
+    elsif Rails.env.development?
+      @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
+    end
     user.membership && (user.membership & @non_admin_group).any?
   end
   

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -37,14 +37,11 @@ class ApplicationPolicy
   end
 
   def user_in_non_admin_group?
+    @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
     if Rails.env.production?
       # When the app is open for the public return true
       # true
       @non_admin_group = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
-    elsif Rails.env.staging?
-      @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
-    elsif Rails.env.development?
-      @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']
     end
     user.membership && (user.membership & @non_admin_group).any?
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -38,6 +38,8 @@ class ApplicationPolicy
 
   def user_in_non_admin_group?
     if Rails.env.production?
+      # When the app is open for the public return true
+      # true
       @non_admin_group = ['mi-classrooms-admin', 'mi-classrooms-non-admin']
     elsif Rails.env.staging?
       @non_admin_group = ['mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging']

--- a/app/policies/floor_policy.rb
+++ b/app/policies/floor_policy.rb
@@ -9,7 +9,6 @@ class FloorPolicy < ApplicationPolicy
   end
 
   def show?
-    # user.admin
     user_in_non_admin_group?
   end
 

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -2,12 +2,10 @@ class NotePolicy < ApplicationPolicy
   
 
   def index?
-    # true
     user_in_non_admin_group?
   end
 
   def show?
-    # true
     user_in_non_admin_group?
   end
 

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -8,7 +8,6 @@ class RoomPolicy < ApplicationPolicy
   end
 
   def index?
-    # true
     user_in_non_admin_group?
   end
 
@@ -17,12 +16,10 @@ class RoomPolicy < ApplicationPolicy
   end
 
   def show?
-    # true
     user_in_non_admin_group?
   end
 
   def floor_plan?
-    # true
     user_in_non_admin_group?
   end
 


### PR DESCRIPTION
I created 'mi-classrooms-admin-staging', 'mi-classrooms-non-admin-staging' mCommunity groups;
tested access in the development environment using test um171712 account.

When the app is open for the public the user_in_non_admin_group? function should return true if Rails.env.production?

I left the pull request in the draft mode because I can't believe it's was so easy to add Rails_env based access. I am afraid I am missing something here.