### PR TITLE
Lra 296 test authentication required and no authorization

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,5 +1,5 @@
 class AnnouncementsController < ApplicationController
-
+  before_action :authenticate_user!
   skip_after_action :verify_policy_scoped, only: :index
 
   before_action :set_announcement, only: [:show, :edit, :update, :cancel]

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -1,5 +1,5 @@
 class BuildingsController < ApplicationController
-
+  before_action :authenticate_user!
   before_action :set_building, only: [:show, :edit, :update, :destroy]
   skip_after_action :verify_policy_scoped, only: :index
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  before_action :authenticate_user!, only: [:room_filters_glossary]
   before_action :set_characteristics_array, only: [:room_filters_glossary]
   def about
     authorize :page

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,7 +1,6 @@
 class RoomsController < ApplicationController
 include ActionView::RecordIdentifier
-  devise_group :logged_in, contains: [:user]
-  before_action :authenticate_logged_in!  
+  before_action :authenticate_user! 
   skip_after_action :verify_policy_scoped, only: :index
   before_action :set_room, only: [:show, :edit, :update, :destroy, :toggle_visibile, :floor_plan]
   before_action :set_filters_list, only: [:index]

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "You need to sign in before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/spec/support/test_seeds.rb
+++ b/spec/support/test_seeds.rb
@@ -1,0 +1,45 @@
+CampusRecord.create([
+  {id: 1,
+  campus_cd: 100,
+  campus_description: "Central Campus"}
+])
+
+
+Building.create!([
+ {bldrecnbr: 1000001,
+ latitude: 42.27743445,
+ longitude: -83.73544073389233,
+ name: "1100 NORTH UNIVERSITY BUILDING",
+ nick_name: "NUB",
+ abbreviation: "1100 NUB",
+ address: "1100 N UNIVERSITY AVE",
+ city: "ANN ARBOR",
+ state: "MI",
+ zip: "48109-1005",
+ country: "usa again",
+ campus_record_id: 1}
+])
+
+Room.create!([
+  {rmrecnbr: 1000010,
+  floor: "01",
+  room_number: "1508",
+  rmtyp_description: "Classroom",
+  dept_id: 171000,
+  dept_grp: "COLLEGE_OF_LSA",
+  dept_description: "LSA Dean: Classrooms",
+  facility_code_heprod: "NUB1508",
+  square_feet: 546,
+  instructional_seating_count: 25,
+  visible: true,
+  building_bldrecnbr: 1000001,
+  dept_group_description: "College of Lit, Science & Arts",
+  building_name: "1100 NORTH UNIVERSITY BUILDING",
+  campus_record_id: 1
+}
+])
+
+Announcement.create!([
+  {location: "home_page"},
+  {location: "find_a_room_page"}
+])

--- a/spec/system/about-page-spec.rb
+++ b/spec/system/about-page-spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Home Page', type: :system do
+
+  describe 'about page' do
+    it 'shows the right content' do
+      visit about_path
+      expect(page).to have_content('About The MClassrooms application')
+      sleep(inspection_time=3)
+    end
+  end
+end

--- a/spec/system/need_to_sign_in-spec.rb
+++ b/spec/system/need_to_sign_in-spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe 'Need to sign in', type: :system do
+
+  before :each do
+    load "#{Rails.root}/spec/support/test_seeds.rb" 
+  end
+
+  describe 'rooms page' do
+    it 'shows the message to sign in' do
+      visit rooms_path
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'buildings page' do
+    it 'shows the message to sign in' do
+      visit buildings_path
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'room show page' do
+    it 'shows the message to sign in' do
+      visit room_path(1000010)
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'room edit page' do
+    it 'shows the message to sign in' do
+      visit edit_room_path(1000010)
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'building show page' do
+    it 'shows the message to sign in' do
+      visit building_path(1000001)
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'building edit page' do
+    it 'shows the message to sign in' do
+      visit edit_building_path(1000001)
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'announcements page' do
+    it 'shows the message to sign in' do
+      visit announcements_path
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'announcement edit page' do
+    it 'shows the message to sign in' do
+      visit announcement_path(1)
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'room_filters_glossary page' do
+    it 'shows the message to sign in' do
+      visit room_filters_glossary_path
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+  describe 'room_filters_glossary page' do
+    it 'message to sign in should dessapear after 3 seconds' do
+      visit room_filters_glossary_path
+      expect(page).to have_content('You need to sign in')
+      sleep(inspection_time=3)
+      expect(page).not_to have_content('You need to sign in')
+      sleep(inspection_time=1)
+    end
+  end
+
+end

--- a/spec/system/test-driver-spec.rb
+++ b/spec/system/test-driver-spec.rb
@@ -1,3 +1,6 @@
+# if needed update chromedriver from here: https://chromedriver.chromium.org/downloads
+# move chromedriver binary into /usr/local/bin or where you need it
+
 require "selenium-webdriver"
 
 driver = Selenium::WebDriver.for :chrome


### PR DESCRIPTION
The branch tests pages that should require authentication. (Authorization should be tested separately - the branch's name is not accurate).

Also, it has some small edits:

- remove “sign up” from the message "You need to sign in or sign up before continuing."
- add before_action :authenticate_user! to buildings_controller, announcements_controller, and pages_controller (room_filters_glossary page only)