### PR TITLE
remove scope from pundit policies

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,7 +1,5 @@
 class AnnouncementsController < ApplicationController
   before_action :authenticate_user!
-  skip_after_action :verify_policy_scoped, only: :index
-
   before_action :set_announcement, only: [:show, :edit, :update, :cancel]
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_in_group
   before_action :set_membership
   after_action :verify_authorized, except: :index, unless: :devise_controller?
-  after_action :verify_policy_scoped, only: :index
 
   private
 

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -1,7 +1,6 @@
 class BuildingsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_building, only: [:show, :edit, :update, :destroy]
-  skip_after_action :verify_policy_scoped, only: :index
 
   # GET /buildings
   # GET /buildings.json

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,7 +1,6 @@
 class RoomsController < ApplicationController
 include ActionView::RecordIdentifier
   before_action :authenticate_user! 
-  skip_after_action :verify_policy_scoped, only: :index
   before_action :set_room, only: [:show, :edit, :update, :destroy, :toggle_visibile, :floor_plan]
   before_action :set_filters_list, only: [:index]
   before_action :set_characteristics_array, only: [:index, :show]

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -46,18 +46,3 @@ class ApplicationPolicy
   end
   
 end
-
- class Scope
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
-    end
-
-    def resolve
-      scope.all
-    end
-
-    private
-
-    attr_reader :user, :scope
-end

--- a/app/policies/building_policy.rb
+++ b/app/policies/building_policy.rb
@@ -1,16 +1,4 @@
 class BuildingPolicy < ApplicationPolicy
-  # include LdapableHelper
-  class Scope < Scope
-
-    def resolve
-      if user && user_in_group?
-        scope.all
-      else
-        # scope.where(visible: true)
-        scope.all
-      end
-    end
-  end
 
   def index?
     user.admin

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,9 +1,5 @@
 class PagePolicy < ApplicationPolicy
-  # class Scope < Scope
-  #   def resolve
-  #     scope.all
-  #   end
-  # end
+  
   def index?
     true
   end

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -1,11 +1,4 @@
 class RoomPolicy < ApplicationPolicy
-  
-  class Scope < Scope
-
-    def resolve
-      scope.all
-    end
-  end
 
   def index?
     user_in_non_admin_group?


### PR DESCRIPTION
I removed scope class from pundit policies and :verify_policy_scoped action from controllers.
Because:

- I don't think we need it
- I am not sure that it was used correctly

Please test this branch on your computer before adding your review.