### PR TITLE
LRA-276 Delete notice on rooms page

### DIFF
--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,7 +1,4 @@
 <%= turbo_frame_tag "room" do  %>
-  <div id="notice">
-    <%= notice %>
-  </div>
   <div class="container rounded-lg shadow-lg px-auto">
     <div class="flex-col w-full px-2">
       <h1>


### PR DESCRIPTION
When a user signs in, we show a notification stating that they are successfully signed in. So, this repetitive information ( marked in red ) is not required on the rooms page ( DRY principle ). Also, this was another change requested in this ticket.


![Screen Shot 2022-04-04 at 5 44 12 PM](https://user-images.githubusercontent.com/80054010/161638834-1aa4fec3-05f0-4872-af84-b993594c7483.png) 