### PR TITLE
remove broken pg_search and go back to sql

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -34,11 +34,11 @@ include ActionView::RecordIdentifier
       @rooms = @rooms.order_as_specified(floor: floors).order(:room_number => :asc)
     end
     @rooms = @rooms.with_building_name(params[:query]) if params[:query].present?
-    @rooms = @rooms.with_classroom_name(params[:classroom_name]) if params[:classroom_name].present?
     @rooms = @rooms.with_school_or_college_name(params[:school_or_college_name]) if params[:school_or_college_name].present?
     @rooms = @rooms.with_all_characteristics(params[:room_characteristics]) if params[:room_characteristics].present?
     @rooms = @rooms.where('instructional_seating_count >= ?', params[:min_capacity].to_i) if params[:max_capacity].present?
     @rooms = @rooms.where('instructional_seating_count <= ?', params[:max_capacity].to_i) if params[:max_capacity].present?
+    @rooms = @rooms.where('facility_code_heprod LIKE ? OR UPPER(nickname) LIKE ?', "%#{params[:classroom_name].upcase}%", "%#{params[:classroom_name].upcase}%") if params[:classroom_name].present?
 
     authorize @rooms
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -56,21 +56,6 @@ class Room < ApplicationRecord
   )
 
   pg_search_scope(
-    :with_classroom_name,
-    against: { 
-      facility_code_heprod: 'A',
-      nickname: 'B'},
-    using: {
-      tsearch: {
-        dictionary: "simple",
-        prefix: true,
-        any_word: false,
-
-      }
-    }
-  )
-
-  pg_search_scope(
     :with_building_name,
     associated_against: {
       building: {name: 'A',


### PR DESCRIPTION
When I added the nickname field to the rooms table and edited the search by room_name adding nicknames to the search, the search broke. 
Search by ‘LSA3242’ - worked, but by ‘3242’ - did not.

I tried to use pg_search and it did not work correctly. I returned back to the SQL query search.

To test that the search by room name works:

- ‘LSA3242’ and ‘3242’  - the same result
- ‘32’ - 21 rooms
- ‘324’ - 2 rooms
- ‘aud’ - 2 rooms