### PR TITLE
Don't include roms with nil facility ID

### DIFF
--- a/app/controllers/buildings/floors_controller.rb
+++ b/app/controllers/buildings/floors_controller.rb
@@ -5,8 +5,8 @@ class Buildings::FloorsController < ApplicationController
   def show 
     @floors = @building.floors
     @floor = @building.floors.find(params[:id])
-    @building_rooms_list = Room.where(building_bldrecnbr: @building, rmtyp_description: "Classroom")
-    @floor_rooms_list = Room.where(building_bldrecnbr: @building, rmtyp_description: "Classroom", floor: @floor.floor).order(:room_number)
+    @building_rooms_list = Room.where(building_bldrecnbr: @building, rmtyp_description: "Classroom").where.not(facility_code_heprod: nil)
+    @floor_rooms_list = Room.where(building_bldrecnbr: @building, rmtyp_description: "Classroom", floor: @floor.floor).where.not(facility_code_heprod: nil).order(:room_number)
     authorize @floors
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -84,7 +84,7 @@ include ActionView::RecordIdentifier
   def floor_plan
     @floor_list = @room.building.floors
     @building = @room.building
-    @rooms_list = Room.where(building_bldrecnbr: @room.building, floor: @room.floor, rmtyp_description: "Classroom").order(:room_number)
+    @rooms_list = Room.where(building_bldrecnbr: @room.building, floor: @room.floor, rmtyp_description: "Classroom").where.not(facility_code_heprod: nil).order(:room_number)
   end
 
   private


### PR DESCRIPTION
The explanation of the problem and solution is in comments for the ticket https://umlsait.atlassian.net/browse/LRA-352.

Another solution is to delete all rooms without Facility IDs from the database. 
After updating the database by the API script we'll need to run another query to delete rooms without Facility IDs. 
Rooms with nil Facility IDs can appear in the database because, first, rooms with the 'Classroom' type are added to the database from the Buildings API. Then Facility ID is added to a room by another API call. 
In this case we can remove [where.not(facility_code_heprod: nil)] from queries.