### PR TITLE
better solution

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,16 +60,16 @@ module ApplicationHelper
   end
 
   def api_status
-    if ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).nil?
+    if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).nil?
       return "failed"
-    elsif ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).status == "error"
+    elsif ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).status == "error"
       return 'error'
     end
   end
 
   def api_log_text
-    if ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).result.present?
-      ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).result
+    if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result.present?
+      ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result
     else
       "The log message is empty"
     end


### PR DESCRIPTION
I think ('created_at >= ?', 24.hours.ago) covers all the time unlike (created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).
The second one makes api_status equal 'failed' from midnight until the time when a record in the ApiUpdateLog table is created.
api_status is used in the header to check if the API script failed to run or ended up with an error.
