### PR TITLE
check if api script has run for the last 24 hours

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,16 +60,16 @@ module ApplicationHelper
   end
 
   def api_status
-    if ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).nil?
+    if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).nil?
       return "failed"
-    elsif ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).status == "error"
+    elsif ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).status == "error"
       return 'error'
     end
   end
 
   def api_log_text
-    if ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).result.present?
-      ApiUpdateLog.find_by(created_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).result
+    if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result.present?
+      ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result
     else
       "The log message is empty"
     end


### PR DESCRIPTION
api_status is used in the header to check if the API script failed to run or ended up with an error.

api_status and api_log_text methods check if the API update script has run for the last 24 hours.