### PR TITLE
Lra 361 mclassrooms add skip to content link to skip the left side menu

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_in_group
   before_action :set_membership
+  before_action :set_skip_links
   after_action :verify_authorized, unless: :devise_controller?
 
   def delete_file_attachment
@@ -32,7 +33,10 @@ class ApplicationController < ActionController::Base
     else
       new_user_session_path
     end
-    
+  end
+
+  def set_skip_links
+    @skip_links = {main: "Skip to main content"}
   end
 
   def set_characteristics_array

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,10 +33,10 @@ module ApplicationHelper
     end
   end
 
-    # Creates skip to content links from an array of id names
-    def skip_links
-      sanitize @skip_links.collect { |skip_link| link_to "#{skip_link[1]}", "##{skip_link[0]}", class: "skip-to-content-link" }.join(" <span class='sr-only' > or </span>")
-    end
+  # Creates skip to content links from an array of id names
+  def skip_links
+    sanitize @skip_links.collect { |skip_link| link_to "#{skip_link[1]}", "##{skip_link[0]}", class: "skip-to-content-link" }.join(" <span class='sr-only' > or </span>")
+  end
 
   def room_thumbnail_image( room )
     if room.room_image.representable?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,10 @@ module ApplicationHelper
     end
   end
 
-
+    # Creates skip to content links from an array of id names
+    def skip_links
+      sanitize @skip_links.collect { |skip_link| link_to "#{skip_link[1]}", "##{skip_link[0]}", class: "skip-to-content-link" }.join(" <span class='sr-only' > or </span>")
+    end
 
   def room_thumbnail_image( room )
     if room.room_image.representable?

--- a/app/packs/stylesheets/application.sass
+++ b/app/packs/stylesheets/application.sass
@@ -171,6 +171,4 @@ ol
     cursor: pointer
 
 .skip-to-content-link
-  @apply sr-only
-  &::focus
-    @apply not-sr-only
+  @apply sr-only font-bold text-2xl text-white focus:not-sr-only focus:bg-green-700 relative self-center flex justify-center  focus:p-5 focus:underline

--- a/app/packs/stylesheets/application.sass
+++ b/app/packs/stylesheets/application.sass
@@ -171,4 +171,4 @@ ol
     cursor: pointer
 
 .skip-to-content-link
-  @apply sr-only font-bold text-2xl text-white focus:not-sr-only focus:bg-green-700 relative self-center flex justify-center  focus:p-5 focus:underline
+  @apply sr-only font-bold text-2xl text-white focus-visible:not-sr-only focus-within:bg-green-700 relative self-center flex justify-center  focus-within:p-5 focus-within:underline

--- a/app/packs/stylesheets/application.sass
+++ b/app/packs/stylesheets/application.sass
@@ -169,3 +169,8 @@ ol
 .checkbox-filter
   [type="checkbox"], label
     cursor: pointer
+
+.skip-to-content-link
+  @apply sr-only
+  &::focus
+    @apply not-sr-only

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,9 +17,8 @@
       = yield :head
 
   %body{'data-environment' => Rails.env}
-    .skip-to-content-link= link_to "Skip to content", "#main"
+    = link_to "Skip to content", "#main", class: "skip-to-content-link"
     #page-top
-    
     = render 'layouts/header'
     - if Rails.env.development?
       = render 'layouts/tailwindcss_breakpoints'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,13 +17,13 @@
       = yield :head
 
   %body{'data-environment' => Rails.env}
+    .skip-to-content-link= link_to "Skip to content", "#main"
     #page-top
     
-
     = render 'layouts/header'
     - if Rails.env.development?
       = render 'layouts/tailwindcss_breakpoints'
-    %main{:class => controller.controller_name}
+    %main{:class => controller.controller_name, id: "main"}
       .max-w-7xl{class: "mx-auto py-6 sm:px-6 lg:px-8"}
         / Replace with your content
         = render 'layouts/flash_messages'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,7 +17,7 @@
       = yield :head
 
   %body{'data-environment' => Rails.env}
-    = link_to "Skip to content", "#main", class: "skip-to-content-link"
+    = skip_links
     #page-top
     = render 'layouts/header'
     - if Rails.env.development?

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,4 +1,4 @@
-<%- @skip_links = {main: "Main Booger", filters: "Filters"} %>
+<%- @skip_links = {filters: "Filters"} %>
 
 <div class="container px-1 mb-20" data-controller='autosubmit'>
   <% if @rooms_page_announcement.present? && @rooms_page_announcement.content.present? %>  

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,3 +1,5 @@
+<%- @skip_links = {main: "Main Booger", filters: "Filters"} %>
+
 <div class="container px-1 mb-20" data-controller='autosubmit'>
   <% if @rooms_page_announcement.present? && @rooms_page_announcement.content.present? %>  
     <div class="relative mb-2">
@@ -33,7 +35,7 @@
   <div>
     <%= form_with url: rooms_path, method: :get, class: "", data: { target: "autosubmit.form" } do |form| %>
       <div class="relative min-h-screen md:flex">
-        <div class="sidebar w-64 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out" data-autosubmit-target="sidebar">
+        <div class="sidebar w-64 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 transition duration-200 ease-in-out" data-autosubmit-target="sidebar" id="filters">
           <% if user_signed_in? && policy(Room).edit? %>
           <p class="bg-blue-700 text-white text-sm p-2">Admin panel</p>
             <div class="bg-blue-700 px-2 pb-2 text-white text-sm checkbox-filter">

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,4 +1,7 @@
-<%- @skip_links = {filters: "Filters"} %>
+
+<%- @skip_links.shift %> 
+<%- @skip_links[:filters] = "Skip to filters" %>
+<%- @skip_links[:rooms] = "Skip to main content" %>
 
 <div class="container px-1 mb-20" data-controller='autosubmit'>
   <% if @rooms_page_announcement.present? && @rooms_page_announcement.content.present? %>  
@@ -109,7 +112,7 @@
               :"data-action" => "change->autosubmit#sortCapacity" %>
             </div>
           </div>
-          <div class="">
+          <div class="" id="rooms">
             <% if user_signed_in? %>
               <%= render 'listing' %>
             <% end %>


### PR DESCRIPTION
We added a skip-to-content link that is visibly HIDDEN on page load using Tailwindcss's sr-only style.

The link is an anchor to the #main id which is applied to the %main element. This will allow a user to navigate using their keyboard and bypass the navigation and other elements between the body of the page and the content. 

As was suggested in the Jira ticket, we used this blog post as our guide https://css-tricks.com/how-to-create-a-skip-to-content-link/, but instead of raw css we utilized tailwindcss.  

Co-authored-by: Debbie Shih dcjshih@umich.edu
Co-authored-by: Henry Teng heteng@umich.edu 