### PR TITLE
LRA-401-mclassrooms-style-looks-broken-when-we-hover-over-sign-in-button

### DIFF
--- a/app/packs/stylesheets/_header.sass
+++ b/app/packs/stylesheets/_header.sass
@@ -13,13 +13,6 @@
   @screen sm
     @apply py-0 ml-4 px-0 justify-end
 
-.user-action-link
-  @apply py-1 px-3 block px-4 py-2 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-500 w-full
-  a
-    @apply  block p-1 -mt-1
-    &:hover
-      @apply text-blue-800 bg-gray-400 rounded
-
 .user-avatar
   @apply h-10 w-10 object-cover rounded-full border-2 border-blue-700 block
   @screen sm

--- a/app/views/layouts/_headness.html.erb
+++ b/app/views/layouts/_headness.html.erb
@@ -40,7 +40,7 @@
                 <div class="px-1 ml-2 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500 flex-1 hover:underline">Sign Out</div>
               <% end %>
             <% else %>
-              <div class="user-action-link">
+              <div>
                 <%= button_to user_saml_omniauth_authorize_path, data: {turbo: "false"} do %>
                   <div class="px-1 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500 hover:underline">Sign In</div>
                 <% end %>

--- a/app/views/layouts/_headness_mobile_menu_dropdown.html.erb
+++ b/app/views/layouts/_headness_mobile_menu_dropdown.html.erb
@@ -18,11 +18,11 @@
               <%= current_user.email %>
             </div>
             <%= button_to destroy_user_session_path, method: :delete, role: "menuitem", tabindex: "-1", data: {turbo: "false"} do  %>
-              <div class="w-60 py-3 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500.hover:underline">Sign Out</div>
+              <div class="w-60 py-3 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500 hover:underline">Sign Out</div>
             <% end %>
           <% else %>
             <%= button_to user_saml_omniauth_authorize_path, data: {turbo: "false"} do %>
-              <div class="w-60 py-3 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500.hover:underline">Sign In</div>
+              <div class="w-60 py-3 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500 hover:underline">Sign In</div>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
There was an old class that was causing a white frame around the sign in button. I removed the class and it's references.
I also fixed some residual haml to erb conversion formatting