### PR TITLE
delete contacts and characteristics before deleting rooms

### DIFF
--- a/lib/buildings_api.rb
+++ b/lib/buildings_api.rb
@@ -262,7 +262,9 @@ class BuildingsApi
         end
         # check if database has rooms that are not in API anymore
         if @rooms_in_db.present?
-          if Room.where(rmrecnbr: @rooms_in_db).destroy_all
+          RoomContact.where(rmrecnbr: @rooms_in_db).delete_all
+          RoomCharacteristic.where(rmrecnbr: @rooms_in_db).delete_all
+          if Room.where(rmrecnbr: @rooms_in_db).delete_all
             @log.api_logger.info "update_rooms, delete #{@rooms_in_db} room(s) from the database"
           else
             @log.api_logger.debug "update_rooms, error: could not delete records with #{@rooms_in_db} rmrecnbr"

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -59,6 +59,8 @@ class ClassroomApi
     end
     # check if database has rooms that are not in API anymore
     if @rooms_in_db.present?
+      RoomContact.where(rmrecnbr: @rooms_in_db).delete_all
+      RoomCharacteristic.where(rmrecnbr: @rooms_in_db).delete_all
       if Room.where(rmrecnbr: @rooms_in_db).delete_all
         @log.api_logger.info "add_facility_id_to_classrooms, delete #{@rooms_in_db} room(s) from the database"
       else


### PR DESCRIPTION
api_update_database is failing to delete a room that is not in the classrooms API anymore because of the following error:

```
PG::ForeignKeyViolation: ERROR: update or delete on table "rooms" violates foreign key constraint "fk_rails_d00a2d31b3" on table "room_characteristics"
DETAIL: Key (rmrecnbr)=(2107046) is still referenced from table "room_characteristics.
```
I believe that happened because rmrecnbr is used as a foreign key in Room - RoomCharacteristic and Room - RoomContact relations. 
Even if the Room model has the following destroy dependencies
```
has_many :room_characteristics, foreign_key: :rmrecnbr, dependent: :destroy
has_one :room_contact, foreign_key: :rmrecnbr, dependent: :destroy
```
the delete_all or destroy _all commands are not working for rooms.

I thought we fixed that by adding id fields to room_contacts and room_characteristis tables, but apparently not.

This is why I added commands to delete room contacts and characteristics before deleting rooms.