### PR TITLE
edit check number of calls and add it to contacts

### DIFF
--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -154,7 +154,7 @@ class ClassroomApi
       if result['errorcode'] == "ERR429"
         @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
         number_of_api_calls_per_minutes = 0
-        sleep(6.seconds)
+        sleep(61.seconds)
         if redo_loop_number > 9
           @debug = true
           @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "


### PR DESCRIPTION
I was not exactly correct in saying (in slack) that “ERR429 - Resource access limit reached” happened after 1 call because it happened in the update_all_classroom_contacts method and I forgot to check for that error in that method. But the method failed with a number of calls less than 400 (so in theory it's possible that it was just one call). 

To be safe I rewrote the code that was looking for the 'access limit reached' error including the check after the first call too. 
Each time that error happened I 'redo' the loop - run the same loop iteration.
To not go into an endless loop I added the number of redo commands = 10. After 10 redo the script will stop and write an error to the log.