### PR TITLE
add compact method to remove 'nil' elments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
 
   def set_characteristics_array
     # create array of room cahracteristics to use in filters
-    characteristics_all = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_descrshort).uniq.sort
+    characteristics_all = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_descrshort).uniq.compact.sort
     @all_characteristics_array = {}
     category_prev = ""
     other = {}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,9 @@ class ApplicationController < ActionController::Base
 
   def set_characteristics_array
     # create array of room cahracteristics to use in filters
-    characteristics_all = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_descrshort).uniq.compact.sort
+    characteristics_all = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_descrshort).uniq
+    characteristics_all.delete_if {|x| x.include?(nil)}
+    characteristics_all.sort
     @all_characteristics_array = {}
     category_prev = ""
     other = {}

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -6,8 +6,7 @@ class BuildingsController < ApplicationController
   # GET /buildings
   # GET /buildings.json
   def index
-    # @searchable_buildings =  Building.with_classrooms.ann_arbor_campus.uniq.pluck(:name, :abbreviation).collect{ |building| [building[0].titleize, building[1] ] }.sort
-    @schools = Room.classrooms.pluck(:dept_group_description).uniq.sort
+    @schools = Room.classrooms.pluck(:dept_group_description).uniq.compact.sort
 
     buildings_ids = Room.classrooms.pluck(:building_bldrecnbr).uniq
     if params[:inactive_buildings].present?
@@ -32,12 +31,12 @@ class BuildingsController < ApplicationController
   # GET /buildings/1
   # GET /buildings/1.json
   def show
-    @class_floor_names = @building.rooms.where(rmtyp_description: "Classroom").pluck(:floor).uniq.sort
+    @class_floor_names = @building.rooms.where(rmtyp_description: "Classroom").pluck(:floor).uniq.compact.sort
   end
 
   # GET /buildings/1/edit
   def edit
-    @floors = @building.rooms.where(rmtyp_description: "Classroom").pluck(:floor).uniq.sort
+    @floors = @building.rooms.where(rmtyp_description: "Classroom").pluck(:floor).uniq.compact.sort
   end
 
   # PATCH/PUT /buildings/1

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,8 +15,8 @@ class PagesController < ApplicationController
 
   def room_filters_glossary
     authorize :page
-    @filters = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_desc254).uniq.sort
-    characteristics = RoomCharacteristic.all.pluck(:chrstc_descrshort, :chrstc_desc254).uniq.sort
+    @filters = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_desc254).uniq.compact.sort
+    characteristics = RoomCharacteristic.all.pluck(:chrstc_descrshort, :chrstc_desc254).uniq.compact.sort
     @filters_hash = {}
     characteristics.each do |key, value|
       @filters_hash[key] = value
@@ -25,7 +25,7 @@ class PagesController < ApplicationController
     @all_characteristics_array.each do |c|
       @category_letters << c[0][0]
     end
-    @category_letters = @category_letters.uniq.sort
+    @category_letters = @category_letters.uniq.compact.sort
   end
 
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,8 +15,12 @@ class PagesController < ApplicationController
 
   def room_filters_glossary
     authorize :page
-    @filters = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_desc254).uniq.compact.sort
-    characteristics = RoomCharacteristic.all.pluck(:chrstc_descrshort, :chrstc_desc254).uniq.compact.sort
+    @filters = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_desc254).uniq
+    @filters.delete_if {|x| x.include?(nil)}
+    @filters.sort
+    characteristics = RoomCharacteristic.all.pluck(:chrstc_descrshort, :chrstc_desc254).uniq
+    characteristics.delete_if {|x| x.include?(nil)}
+    characteristics.sort
     @filters_hash = {}
     characteristics.each do |key, value|
       @filters_hash[key] = value
@@ -25,7 +29,7 @@ class PagesController < ApplicationController
     @all_characteristics_array.each do |c|
       @category_letters << c[0][0]
     end
-    @category_letters = @category_letters.uniq.compact.sort
+    @category_letters = @category_letters.uniq.sort
   end
 
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -20,7 +20,7 @@ include ActionView::RecordIdentifier
 
     @rooms_page_announcement = Announcement.find_by(location: "find_a_room_page")
     @all_rooms_number = Room.classrooms.count
-    @schools = Room.classrooms.pluck(:dept_group_description).uniq.sort
+    @schools = Room.classrooms.pluck(:dept_group_description).uniq.compact.sort
     if params[:inactive_rooms].present?
       @rooms = Room.classrooms_inactive
     else

--- a/app/jobs/update_room_characteristics_array_job.rb
+++ b/app/jobs/update_room_characteristics_array_job.rb
@@ -11,7 +11,7 @@ class UpdateRoomCharacteristicsArrayJob < ApplicationJob
     rmrecnbrs = RoomCharacteristic.pluck(:rmrecnbr).uniq
     rmrecnbrs.each do |rmrecnbr|
       room = Room.find_by(rmrecnbr: rmrecnbr)
-      chars = RoomCharacteristic.where(rmrecnbr: rmrecnbr).pluck(:chrstc_descrshort).uniq.sort
+      chars = RoomCharacteristic.where(rmrecnbr: rmrecnbr).pluck(:chrstc_descrshort).uniq.compact.sort
 
       room.characteristics = chars
       room.save

--- a/app/jobs/update_user_groups_job.rb
+++ b/app/jobs/update_user_groups_job.rb
@@ -5,7 +5,7 @@ class UpdateUserGroupsJob < ApplicationJob
   def perform(*args)
     # Do something later
     user = arguments.first
-    user.mcommunity_groups = user_group_memberships(user.uniqname).sort.to_json
+    user.mcommunity_groups = user_group_memberships(user.uniqname).compact.sort.to_json
     user.save
   end
 end

--- a/app/views/pages/room_filters_glossary.html.erb
+++ b/app/views/pages/room_filters_glossary.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <% prev_cat = "" %> 
-    <% @all_characteristics_array.compact.sort.each do |category, list| %>
+    <% @all_characteristics_array.sort.each do |category, list| %>
       <% cat = category[0] %>
       <% if cat != prev_cat %>
         <div class="mb-2" id="<%= cat %>">

--- a/app/views/pages/room_filters_glossary.html.erb
+++ b/app/views/pages/room_filters_glossary.html.erb
@@ -15,7 +15,7 @@
   </div>
   <div>
     <% prev_cat = "" %> 
-    <% @all_characteristics_array.sort.each do |category, list| %>
+    <% @all_characteristics_array.compact.sort.each do |category, list| %>
       <% cat = category[0] %>
       <% if cat != prev_cat %>
         <div class="mb-2" id="<%= cat %>">


### PR DESCRIPTION
To whom it may concern,
This PR was created in order to fix the error: `sort': comparison of NilClass with String failed (ArgumentError).

It adds '.compact' before the '.sort' of the arrays that are created via ActiveRecord queries.

Please submit any complaints to the management.