### PR TITLE
LRA 708 - code optimization of login workflow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,12 @@ class ApplicationController < ActionController::Base
     redirect_back(fallback_location: rooms_path)
   end
 
+  def set_redirection_url
+    unless user_signed_in?
+      $baseURL = request.fullpath
+    end
+  end
+
   private
 
   def user_not_authorized

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -55,10 +55,6 @@ class BuildingsController < ApplicationController
 
   private
 
-    def set_redirection_url
-      $baseURL = request.fullpath
-    end
-
     # Use callbacks to share common setup or constraints between actions.
     def set_building
       @building = Building.find(params[:id])

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -94,10 +94,6 @@ include ActionView::RecordIdentifier
 
   private
 
-    def set_redirection_url
-      $baseURL = request.fullpath
-    end
-
     def set_room
       # fresh_when @room
       # @room = Room.includes(:building, :room_characteristics, :room_panorama_attachment, :room_contact).find(params[:id])

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -34,6 +34,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     else
       sign_in_and_redirect user, event: :authentication
+      $baseURL = ''
       set_flash_message :notice, :success, kind: kind
     end
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,1 @@
+<% controller.redirect_to root_path %>


### PR DESCRIPTION
- While working on code optimization of login workflow, I found that the device view **/users/sign_in** was still showing up. In order to fix this issue, I have added back one device view to override out the box behavior.