### PR TITLE
Update Main with dependabot security fix (#298)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "rails", "~> 6.1.5"
 gem "redis", "~> 5.0", ">= 5.0.6"
 gem "responders", github: "heartcombo/responders"
 gem "sassc-rails"
-gem "sidekiq", "~> 7.0.8"
+gem "sidekiq", "~> 7.1.3"
 gem "skylight"
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "uglifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       ffi (~> 1.0)
     redis (5.0.7)
       redis-client (>= 0.9.0)
-    redis-client (0.16.0)
+    redis-client (0.17.0)
       connection_pool
     regexp_parser (2.8.1)
     request_store (1.5.1)
@@ -380,11 +380,11 @@ GEM
     sexp_processor (4.17.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.9)
+    sidekiq (7.1.3)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
-      redis-client (>= 0.11.0)
+      redis-client (>= 0.14.0)
     skylight (5.3.4)
       activesupport (>= 5.2.0)
     snaky_hash (2.0.1)
@@ -493,7 +493,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   shoulda-matchers
-  sidekiq (~> 7.0.8)
+  sidekiq (~> 7.1.3)
   skylight
   spring
   spring-watcher-listen


### PR DESCRIPTION
* Bump semver from 5.7.1 to 5.7.2 (#290)

Bumps [semver](https://github.com/npm/node-semver) from 5.7.1 to 5.7.2.
- [Release notes](https://github.com/npm/node-semver/releases)
- [Changelog](https://github.com/npm/node-semver/blob/v5.7.2/CHANGELOG.md)
- [Commits](https://github.com/npm/node-semver/compare/v5.7.1...v5.7.2)

---
updated-dependencies:
- dependency-name: semver dependency-type: indirect ...




* Fix-redis-issue (#293)

* Remove bad gems and add missing ones

* update config to remove unneeded values

* delete unneeded initializer

* varaibles are called DEFAULT rather VARS

* needed to add hatchbox platform

* Bump puma from 4.3.12 to 5.6.7 (#294)

Bumps [puma](https://github.com/puma/puma) from 4.3.12 to 5.6.7.
- [Release notes](https://github.com/puma/puma/releases)
- [Changelog](https://github.com/puma/puma/blob/master/History.md)
- [Commits](https://github.com/puma/puma/compare/v4.3.12...v5.6.7)

---
updated-dependencies:
- dependency-name: puma dependency-type: direct:production ...




* Solution for error No route matches [GET] (#292)

* remove registerable from devise

* elegant error for No route matches [GET]

* remove recoverable from User model

* remove not_found method

* remove validatable

* remove views/devise folder

* LRA 708 - code optimization of login workflow (#295)

* LRA-708 code optimization

* LRA-708 Added device view to override out of box device login view with route /users/sign_in

* fix duplicate entry

* bundle update

* Bump sidekiq from 7.0.9 to 7.1.3 (#297)

Bumps [sidekiq](https://github.com/sidekiq/sidekiq) from 7.0.9 to 7.1.3.
- [Changelog](https://github.com/sidekiq/sidekiq/blob/main/Changes.md)
- [Commits](https://github.com/sidekiq/sidekiq/compare/v7.0.9...v7.1.3)

---
updated-dependencies:
- dependency-name: sidekiq dependency-type: direct:production ...




---------