### PR TITLE
add-platform x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -450,6 +452,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   annotate (~> 3.1.1)


### PR DESCRIPTION
need to add-platform x86_64-linux to the gemfile.lock for hatchbox