### PR TITLE
Lra 833 m classrooms migrate to the newest version of the classrooms api

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,4 @@
 ruby 3.1.0
+bundler 2.5.9
+nodejs 18.18.2
+yarn 1.22.19

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,14 +60,14 @@ module ApplicationHelper
   def api_status
     if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).nil?
       return "failed"
-    elsif ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).status == "error"
+    elsif ApiUpdateLog.where('created_at >= ?', 24.hours.ago).last.status == "error"
       return 'error'
     end
   end
 
   def api_log_text
-    if ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result.present?
-      ApiUpdateLog.find_by('created_at >= ?', 24.hours.ago).result
+    if ApiUpdateLog.where('created_at >= ?', 24.hours.ago).last.result.present?
+      ApiUpdateLog.where('created_at >= ?', 24.hours.ago).last.result
     else
       "The log message is empty"
     end

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -8,190 +8,229 @@ class ClassroomApi
   end
 
   def add_facility_id_to_classrooms
-    @rooms_in_db = Room.all.pluck(:rmrecnbr)
-    result = get_classrooms_list
-    if result['success']
-      classrooms_list = result['data'] 
-      number_of_api_calls_per_minutes = 0
-      redo_loop_number = 1
-      classrooms_list.each do |room|
-        # update only rooms for campuses and buildings from the MClassroom database
-        if @buildings_ids.include?(room['BuildingID'].to_i)
-          if number_of_api_calls_per_minutes < 400
-            number_of_api_calls_per_minutes += 1
-          else
-            @log.api_logger.debug "add_facility_id_to_classrooms, the script sleeps after #{number_of_api_calls_per_minutes} calls"
-            number_of_api_calls_per_minutes = 1
-            sleep(61.seconds)
-          end
-          facility_id = room['FacilityID'].to_s
-          # add facility_id and number of seats
-          result = get_classroom_info(ERB::Util.url_encode(facility_id))
-          if result['errorcode'] == "ERR429"
-            @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
-            number_of_api_calls_per_minutes = 0
-            sleep(61.seconds)
-            if redo_loop_number > 9
-              @debug = true
-              @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
-              return @debug
+    begin
+      @rooms_in_db = Room.all.pluck(:rmrecnbr)
+      result = get_classrooms_list
+      if result['success']
+        classrooms_list = result['data']
+        number_of_api_calls_per_minutes = 0
+        redo_loop_number = 1
+        classrooms_list.each do |room|
+          # update only rooms for campuses and buildings from the MClassroom database
+          if @buildings_ids.include?(room['BuildingID'].to_i)
+            if number_of_api_calls_per_minutes < 400
+              number_of_api_calls_per_minutes += 1
+            else
+              @log.api_logger.debug "add_facility_id_to_classrooms, the script sleeps after #{number_of_api_calls_per_minutes} calls"
+              number_of_api_calls_per_minutes = 1
+              sleep(61.seconds)
             end
-            redo_loop_number += 1
-            redo
-          elsif result['success']
-            room_info = result['data'][0]
-            rmrecnbr = room_info['RmRecNbr'].to_i
-            room_in_db = Room.find_by(rmrecnbr: rmrecnbr)
-            if room_in_db
-              if room_in_db.update(facility_code_heprod: facility_id, instructional_seating_count: room_info['RmInstSeatCnt'], campus_record_id: CampusRecord.find_by(campus_cd: room_info['CampusCd']).id)
-                @rooms_in_db.delete(rmrecnbr)
-              else
-                @log.api_logger.debug "add_facility_id_to_classrooms, error: Could not update: rmrecnbr - #{rmrecnbr}, facility_id - #{facility_id}"
+            facility_id = room['FacilityID'].to_s
+            # add facility_id and number of seats
+            result = get_classroom_info(ERB::Util.url_encode(facility_id))
+            if result['errorcode'] == "ERR429"
+              @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
+              number_of_api_calls_per_minutes = 0
+              sleep(61.seconds)
+              if redo_loop_number > 9
                 @debug = true
+                @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
                 return @debug
               end
+              redo_loop_number += 1
+              redo
+            elsif result['success'] 
+              if result['data']['Classroom'].present?
+                room_info = result['data']['Classroom'][0]
+                rmrecnbr = room_info['RmRecNbr'].to_i
+                room_in_db = Room.find_by(rmrecnbr: rmrecnbr)
+                if room_in_db
+                  if room_in_db.update(facility_code_heprod: facility_id, instructional_seating_count: room_info['RmInstSeatCnt'], campus_record_id: CampusRecord.find_by(campus_cd: room_info['CampusCd']).id)
+                    @rooms_in_db.delete(rmrecnbr)
+                  else
+                    @log.api_logger.debug "add_facility_id_to_classrooms, error: Could not update: rmrecnbr - #{rmrecnbr}, facility_id - #{facility_id}"
+                    @debug = true
+                    return @debug
+                  end
+                end
+              end
+            else
+              @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} for #{facility_id}"
+              @debug = true
+              return @debug
             end
-          else
-            @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} for #{facility_id}"
-            @debug = true
-            return @debug
           end
         end
-      end
-    else
-      @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} for #{facility_id}"
-      @debug = true
-      return @debug
-    end
-    # check if database has rooms that are not in API anymore
-    if @rooms_in_db.present?
-      RoomContact.where(rmrecnbr: @rooms_in_db).delete_all
-      RoomCharacteristic.where(rmrecnbr: @rooms_in_db).delete_all
-      if Room.where(rmrecnbr: @rooms_in_db).delete_all
-        @log.api_logger.info "add_facility_id_to_classrooms, delete #{@rooms_in_db} room(s) from the database"
       else
-        @log.api_logger.debug "add_facility_id_to_classrooms, error: could not delete records with #{@rooms_in_db} rmrecnbr"
+        @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} for #{facility_id}"
         @debug = true
         return @debug
       end
+      # check if database has rooms that are not in API anymore
+      if @rooms_in_db.present?
+        RoomContact.where(rmrecnbr: @rooms_in_db).delete_all
+        RoomCharacteristic.where(rmrecnbr: @rooms_in_db).delete_all
+        if Room.where(rmrecnbr: @rooms_in_db).delete_all
+          @log.api_logger.info "add_facility_id_to_classrooms, delete #{@rooms_in_db} room(s) from the database"
+        else
+          @log.api_logger.debug "add_facility_id_to_classrooms, error: could not delete records with #{@rooms_in_db} rmrecnbr"
+          @debug = true
+          return @debug
+        end
+      end
+    rescue StandardError => e
+      # example: Errno::ETIMEDOUT: Operation timed out - user specified timeout
+      @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{e.message}"
+      @debug = true
     end
     return @debug
   end
 
 
   def get_classrooms_list
-    result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
-    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/Classrooms?BuildingID=1005046")
+    begin
+      result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
+      classrooms = []
+      start_index = 0
+      count = 1000
+      next_page = true
+      while next_page do
+        url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/v2/Classrooms?$start_index=#{start_index}&$count=#{count}")
 
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    request = Net::HTTP::Get.new(url)
-    request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
-    request["authorization"] = "Bearer #{@access_token}"
-    request["accept"] = 'application/json'
+        request = Net::HTTP::Get.new(url)
+        request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
+        request["authorization"] = "Bearer #{@access_token}"
+        request["accept"] = 'application/json'
 
-    response = http.request(request)
-    response_json = JSON.parse(response.read_body)
-    if response_json['errorCode'].present?
-      result['errorcode'] = response_json['errorCode']
-      result['error'] = response_json['errorMessage']
-    else
-      result['success'] = true
-      result['data'] = response_json['Classrooms']['Classroom']
+        response = http.request(request)
+        link = response.to_hash["link"].to_s
+        if link.include? "rel=next"
+          start_index += 1000
+        else
+          next_page = false
+        end
+        response_json = JSON.parse(response.read_body)
+        if response.code == "200"
+          result['success'] = true
+          classrooms += response_json['Classrooms']['Classroom']
+        elsif response_json['errorCode'].present?
+          result['errorcode'] = response_json['errorCode']
+          result['error'] = response_json['errorMessage']
+          next_page = false
+        else 
+          result['errorcode'] = "Unknown error"
+          next_page = false
+        end
+      end
+      result['data'] = classrooms
+    rescue StandardError => e
+      result['errorcode'] = "Exception"
+      result['error'] = e.message
     end
     return result
-    
   end
 
   def get_classroom_info(facility_id)
-    result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
-    @debug = false
-    
-    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/Classrooms/#{facility_id}")
+    begin
+      result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
+      @debug = false
+      
+      url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/v2/Classrooms/#{facility_id}")
 
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    request = Net::HTTP::Get.new(url)
-    request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
-    request["authorization"] = "Bearer #{@access_token}"
-    request["accept"] = 'application/json'
+      request = Net::HTTP::Get.new(url)
+      request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
+      request["authorization"] = "Bearer #{@access_token}"
+      request["accept"] = 'application/json'
 
-    response = http.request(request)
-    response_json = JSON.parse(response.read_body)
-    if response_json.present?
-      if response_json['errorCode'].present?
+      response = http.request(request)
+      response_json = JSON.parse(response.read_body)
+
+      if response.code == "200"
+        result['success'] = true
+        result['data'] = response_json['Classrooms']
+      elsif response_json['errorCode'].present?
         result['errorcode'] = response_json['errorCode']
         result['error'] = response_json['errorMessage']
-        result['success'] = false
-      else
-        result['success'] = true
-        result['data'] = response_json['Classrooms']['Classroom']
+      else 
+        result['errorcode'] = "Unknown error"
       end
+    rescue StandardError => e
+      result['errorcode'] = "Exception"
+      result['error'] = e.message
     end
     return result
   end
 
   def update_all_classroom_characteristics
-
-    classrooms = Room.where(rmtyp_description: "Classroom").where.not(facility_code_heprod: nil)
-    number_of_api_calls_per_minutes = 0
-    redo_loop_number = 1
-    classrooms.each do |room|
-      if number_of_api_calls_per_minutes < 400
-        number_of_api_calls_per_minutes += 1
-      else
-        @log.api_logger.debug "update_all_classroom_characteristics, the script sleeps after #{number_of_api_calls_per_minutes} calls"
-        number_of_api_calls_per_minutes = 1
-        sleep(61.seconds)
-      end
-      facility_id = room.facility_code_heprod
-      rmrecnbr = room.rmrecnbr
-      result = get_classroom_characteristics(ERB::Util.url_encode(facility_id))
-      if result['errorcode'] == "ERR429"
-        @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
-        number_of_api_calls_per_minutes = 0
-        sleep(61.seconds)
-        if redo_loop_number > 9
-          @debug = true
-          @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
-          return @debug
+    begin
+      classrooms = Room.where(rmtyp_description: "Classroom").where.not(facility_code_heprod: nil)
+      number_of_api_calls_per_minutes = 0
+      redo_loop_number = 1
+      classrooms.each do |room|
+        if number_of_api_calls_per_minutes < 400
+          number_of_api_calls_per_minutes += 1
+        else
+          @log.api_logger.debug "update_all_classroom_characteristics, the script sleeps after #{number_of_api_calls_per_minutes} calls"
+          number_of_api_calls_per_minutes = 1
+          sleep(61.seconds)
         end
-        redo_loop_number += 1
-        redo
-      elsif result['success']
-        if result['data']['Characteristics'].present?
-          characteristics = result['data']['Characteristics']['Characteristic']
-          if RoomCharacteristic.where(rmrecnbr: rmrecnbr).present?
-            db_chrstc_list = RoomCharacteristic.where(rmrecnbr: rmrecnbr).pluck(:chrstc)
-            characteristics.each do |c|
-              # add characteristics if they are not in database
-              if db_chrstc_list.include?(c['Chrstc'].to_i)
-                db_chrstc_list.delete(c['Chrstc'].to_i)
-              else
-                add_classroom_characteristic(c)
+        facility_id = room.facility_code_heprod
+        rmrecnbr = room.rmrecnbr
+        result = get_classroom_characteristics(ERB::Util.url_encode(facility_id))
+        if result['errorcode'] == "ERR429"
+          @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
+          number_of_api_calls_per_minutes = 0
+          sleep(61.seconds)
+          if redo_loop_number > 9
+            @debug = true
+            @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
+            return @debug
+          end
+          redo_loop_number += 1
+          redo
+        elsif result['success']
+          if result['data']['Classroom'].present?
+            characteristics = result['data']['Classroom']
+            if RoomCharacteristic.where(rmrecnbr: rmrecnbr).present?
+              db_chrstc_list = RoomCharacteristic.where(rmrecnbr: rmrecnbr).pluck(:chrstc)
+              characteristics.each do |c|
+                # add characteristics if they are not in database
+                if db_chrstc_list.include?(c['Chrstc'].to_i)
+                  db_chrstc_list.delete(c['Chrstc'].to_i)
+                else
+                  add_classroom_characteristic(c)
+                end
+                return @debug if @debug
               end
-              return @debug if @debug
-            end
-            # delete characteristics that are not in API
-            db_chrstc_list.each do |c|
-              RoomCharacteristic.where(rmrecnbr: rmrecnbr).where(chrstc: c).delete_all
+              # delete characteristics that are not in API
+              db_chrstc_list.each do |c|
+                RoomCharacteristic.where(rmrecnbr: rmrecnbr).where(chrstc: c).delete_all
+              end
+            else
+              create_classroom_characteristics(characteristics)
             end
           else
-            create_classroom_characteristics(characteristics)
+            @log.api_logger.info "update_all_classroom_characteristics, no characteristics for facility_id: #{facility_id}"
           end
         else
-          @log.api_logger.info "update_all_classroom_characteristics, no characteristics for facility_id: #{facility_id}"
+          @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']}"
+          @debug = true
+          return @debug
         end
-      else
-        @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']}"
-        @debug = true
-        return @debug
+        return @debug if @debug
       end
-      return @debug if @debug
+    rescue StandardError => e
+      # example: Errno::ETIMEDOUT: Operation timed out - user specified timeout
+      @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{e.message}"
+      @debug = true
     end
     return @debug
   end
@@ -222,79 +261,92 @@ class ClassroomApi
   end
 
   def get_classroom_characteristics(facility_id)
-    result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
-    @debug = false
-    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/Classrooms/#{facility_id}/Characteristics")
+    begin
+      result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
+      @debug = false
+      url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/v2/Classrooms/#{facility_id}/Characteristics")
 
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    request = Net::HTTP::Get.new(url)
-    request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
-    request["authorization"] = "Bearer #{@access_token}"
-    request["accept"] = 'application/json'
+      request = Net::HTTP::Get.new(url)
+      request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
+      request["authorization"] = "Bearer #{@access_token}"
+      request["accept"] = 'application/json'
 
-    response = http.request(request)
-    response_json = JSON.parse(response.read_body)
+      response = http.request(request)
+      response_json = JSON.parse(response.read_body)
 
-    if response_json['errorCode'].present?
-      result['errorcode'] = response_json['errorCode']
-      result['error'] = response_json['errorMessage']
-    else
-      result['success'] = true
-      result['data'] = response_json
+      if response.code == "200"
+        result['success'] = true
+        result['data'] = response_json['Classrooms']
+      elsif response_json['errorCode'].present?
+        result['errorcode'] = response_json['errorCode']
+        result['error'] = response_json['errorMessage']
+      else 
+        result['errorcode'] = "Unknown error"
+      end
+    rescue StandardError => e
+      result['errorcode'] = "Exception"
+      result['error'] = e.message
     end
     return result
 
   end
 
   def update_all_classroom_contacts
-    result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
-    @debug = false
-    classrooms = Room.where(rmtyp_description: "Classroom").where.not(facility_code_heprod: nil)
-    number_of_api_calls_per_minutes = 0
-    redo_loop_number = 1
-    classrooms.each do |room|
-      if number_of_api_calls_per_minutes < 400
-        number_of_api_calls_per_minutes += 1
-      else
-        @log.api_logger.debug "update_all_classroom_contacts, the script sleeps after #{number_of_api_calls_per_minutes} calls"
-        number_of_api_calls_per_minutes = 1
-        sleep(61.seconds)
-      end
-      facility_id = room.facility_code_heprod
-      rmrecnbr = room.rmrecnbr
-      result = get_classroom_contact(ERB::Util.url_encode(facility_id))
-      if result['errorcode'] == "ERR429"
-        @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
-        number_of_api_calls_per_minutes = 0
-        sleep(61.seconds)
-        if redo_loop_number > 9
-          @debug = true
-          @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
-          return @debug
+    begin
+      result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
+      @debug = false
+      classrooms = Room.where(rmtyp_description: "Classroom").where.not(facility_code_heprod: nil)
+      number_of_api_calls_per_minutes = 0
+      redo_loop_number = 1
+      classrooms.each do |room|
+        if number_of_api_calls_per_minutes < 400
+          number_of_api_calls_per_minutes += 1
+        else
+          @log.api_logger.debug "update_all_classroom_contacts, the script sleeps after #{number_of_api_calls_per_minutes} calls"
+          number_of_api_calls_per_minutes = 1
+          sleep(61.seconds)
         end
-        redo_loop_number += 1
-        redo
-      elsif result['success']
-        if result['data']['Classrooms'].present?
-          row = result['data']['Classrooms']['Classroom'][0]
-          
-          if RoomContact.find_by(rmrecnbr: rmrecnbr).present?
-            update_classroom_contact(row, rmrecnbr)
+        facility_id = room.facility_code_heprod
+        rmrecnbr = room.rmrecnbr
+        result = get_classroom_contact(ERB::Util.url_encode(facility_id))
+        if result['errorcode'] == "ERR429"
+          @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
+          number_of_api_calls_per_minutes = 0
+          sleep(61.seconds)
+          if redo_loop_number > 9
+            @debug = true
+            @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls #{redo_loop_number} times "
+            return @debug
+          end
+          redo_loop_number += 1
+          redo
+        elsif result['success']
+          if result['data']['Classroom'].present?
+            row = result['data']['Classroom'][0]
+            
+            if RoomContact.find_by(rmrecnbr: rmrecnbr).present?
+              update_classroom_contact(row, rmrecnbr)
+            else
+              create_classroom_contact(row, rmrecnbr)
+            end
           else
-            create_classroom_contact(row, rmrecnbr)
+            @log.api_logger.info "update_all_classroom_contacts, No contacts for facility_id #{facility_id}"
           end
         else
-          @log.api_logger.info "update_all_classroom_contacts, No contacts for facility_id #{facility_id}"
+          @log.api_logger.debug "update_all_classroom_contacts, error: API returns false for facility_id #{facility_id}: #{result['errorcode']} - #{result['error']}"
+          @debug = true
+          return @debug
         end
-      else
-        @log.api_logger.debug "update_all_classroom_contacts, error: API returns false for facility_id #{facility_id}: #{result['errorcode']} - #{result['error']}"
-        @debug = true
-        return @debug
+        return @debug if @debug
       end
-      return @debug if @debug
+    rescue StandardError => e
+      # example: Errno::ETIMEDOUT: Operation timed out - user specified timeout
+      @log.api_logger.debug "update_rooms, error: API return: #{e.message}"
+      @debug = true
     end
     return @debug
   end
@@ -323,33 +375,38 @@ class ClassroomApi
   end
 
   def get_classroom_contact(facility_id)
-    result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
-    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/Classrooms/#{facility_id}/Contacts")
-    http = Net::HTTP.new(url.host, url.port)
-    http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    begin
+      result = {'success' => false, 'errorcode' => '', 'error' => '', 'data' => {}}
+      url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/v2/Classrooms/#{facility_id}/Contacts")
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-    request = Net::HTTP::Get.new(url)
-    request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
-    request["authorization"] = "Bearer #{@access_token}"
-    request["accept"] = 'application/json'
+      request = Net::HTTP::Get.new(url)
+      request["x-ibm-client-id"] = "#{Rails.application.credentials.um_api[:buildings_client_id]}"
+      request["authorization"] = "Bearer #{@access_token}"
+      request["accept"] = 'application/json'
 
-    response = http.request(request)
-    response_json = JSON.parse(response.read_body)
+      response = http.request(request)
+      response_json = JSON.parse(response.read_body)
 
-    if response_json['errorCode'].present?
-      result['errorcode'] = response_json['errorCode']
-      result['error'] = response_json['errorMessage']
-    else
-      result['success'] = true
-      result['data'] = response_json
+      if response_json['errorCode'].present?
+        result['errorcode'] = response_json['errorCode']
+        result['error'] = response_json['errorMessage']
+      else
+        result['success'] = true
+        result['data'] = response_json['Classrooms']
+      end
+    rescue StandardError => e
+      result['errorcode'] = "Exception"
+      result['error'] = e.message
     end
     return result
 
   end
 
   def get_classroom_meetings(start_date, end_date)
-    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/Classrooms/#{@rmrecnbr}/Meetings?startDate=#{start_date}&endDate=#{end_date}")
+    url = URI("https://gw.api.it.umich.edu/um/aa/ClassroomList/v2/Classrooms/#{@rmrecnbr}/Meetings?startDate=#{start_date}&endDate=#{end_date}")
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -361,7 +418,7 @@ class ClassroomApi
 
     response = http.request(request)
     return JSON.parse(response.read_body)
- 
+
   end
 
 end

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -390,19 +390,20 @@ class ClassroomApi
       response = http.request(request)
       response_json = JSON.parse(response.read_body)
 
-      if response_json['errorCode'].present?
-        result['errorcode'] = response_json['errorCode']
-        result['error'] = response_json['errorMessage']
-      else
+      if response.code == "200"
         result['success'] = true
         result['data'] = response_json['Classrooms']
+      elsif response_json['errorCode'].present?
+        result['errorcode'] = response_json['errorCode']
+        result['error'] = response_json['errorMessage']
+      else 
+        result['errorcode'] = "Unknown error"
       end
     rescue StandardError => e
       result['errorcode'] = "Exception"
       result['error'] = e.message
     end
     return result
-
   end
 
   def get_classroom_meetings(start_date, end_date)

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -109,7 +109,7 @@ class ClassroomApi
         response = http.request(request)
         link = response.to_hash["link"].to_s
         if link.include? "rel=next"
-          start_index += 1000
+          start_index += count
         else
           next_page = false
         end

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -42,7 +42,7 @@ class ClassroomApi
               redo_loop_number += 1
               redo
             elsif result['success'] 
-              if result['data']['Classroom'].present?
+              if result['data']['Classroom'][0].present?
                 room_info = result['data']['Classroom'][0]
                 rmrecnbr = room_info['RmRecNbr'].to_i
                 room_in_db = Room.find_by(rmrecnbr: rmrecnbr)

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -1,7 +1,8 @@
 class ClassroomApi
 
-  ERR429 = "ERR429"
+  ERROR_CODE_ERR429 = "ERR429"
   OK_CODE = "200"
+  NUMBER_OF_API_CALLS = 400
 
   def initialize(access_token)
     @buildings_ids = Building.all.pluck(:bldrecnbr)
@@ -21,7 +22,7 @@ class ClassroomApi
         classrooms_list.each do |room|
           # update only rooms for campuses and buildings from the MClassroom database
           if @buildings_ids.include?(room['BuildingID'].to_i)
-            if number_of_api_calls_per_minutes < 400
+            if number_of_api_calls_per_minutes < NUMBER_OF_API_CALLS
               number_of_api_calls_per_minutes += 1
             else
               @log.api_logger.debug "add_facility_id_to_classrooms, the script sleeps after #{number_of_api_calls_per_minutes} calls"
@@ -31,7 +32,7 @@ class ClassroomApi
             facility_id = room['FacilityID'].to_s
             # add facility_id and number of seats
             result = get_classroom_info(ERB::Util.url_encode(facility_id))
-            if result['errorcode'] == ERR429
+            if result['errorcode'] == ERROR_CODE_ERR429
               @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
               number_of_api_calls_per_minutes = 0
               sleep(61.seconds)
@@ -178,7 +179,7 @@ class ClassroomApi
       number_of_api_calls_per_minutes = 0
       redo_loop_number = 1
       classrooms.each do |room|
-        if number_of_api_calls_per_minutes < 400
+        if number_of_api_calls_per_minutes < NUMBER_OF_API_CALLS
           number_of_api_calls_per_minutes += 1
         else
           @log.api_logger.debug "update_all_classroom_characteristics, the script sleeps after #{number_of_api_calls_per_minutes} calls"
@@ -188,7 +189,7 @@ class ClassroomApi
         facility_id = room.facility_code_heprod
         rmrecnbr = room.rmrecnbr
         result = get_classroom_characteristics(ERB::Util.url_encode(facility_id))
-        if result['errorcode'] == ERR429
+        if result['errorcode'] == ERROR_CODE_ERR429
           @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
           number_of_api_calls_per_minutes = 0
           sleep(61.seconds)
@@ -306,7 +307,7 @@ class ClassroomApi
       number_of_api_calls_per_minutes = 0
       redo_loop_number = 1
       classrooms.each do |room|
-        if number_of_api_calls_per_minutes < 400
+        if number_of_api_calls_per_minutes < NUMBER_OF_API_CALLS
           number_of_api_calls_per_minutes += 1
         else
           @log.api_logger.debug "update_all_classroom_contacts, the script sleeps after #{number_of_api_calls_per_minutes} calls"
@@ -316,7 +317,7 @@ class ClassroomApi
         facility_id = room.facility_code_heprod
         rmrecnbr = room.rmrecnbr
         result = get_classroom_contact(ERB::Util.url_encode(facility_id))
-        if result['errorcode'] == ERR429
+        if result['errorcode'] == ERROR_CODE_ERR429
           @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
           number_of_api_calls_per_minutes = 0
           sleep(61.seconds)

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -1,6 +1,7 @@
 class ClassroomApi
 
   ERR429 = "ERR429"
+  OK_CODE = "200"
 
   def initialize(access_token)
     @buildings_ids = Building.all.pluck(:bldrecnbr)
@@ -116,7 +117,7 @@ class ClassroomApi
           next_page = false
         end
         response_json = JSON.parse(response.read_body)
-        if response.code == "200"
+        if response.code == OK_CODE
           result['success'] = true
           classrooms += response_json['Classrooms']['Classroom']
         elsif response_json['errorCode'].present?
@@ -155,7 +156,7 @@ class ClassroomApi
       response = http.request(request)
       response_json = JSON.parse(response.read_body)
 
-      if response.code == "200"
+      if response.code == OK_CODE
         result['success'] = true
         result['data'] = response_json['Classrooms']
       elsif response_json['errorCode'].present?
@@ -280,7 +281,7 @@ class ClassroomApi
       response = http.request(request)
       response_json = JSON.parse(response.read_body)
 
-      if response.code == "200"
+      if response.code == OK_CODE
         result['success'] = true
         result['data'] = response_json['Classrooms']
       elsif response_json['errorCode'].present?
@@ -391,7 +392,7 @@ class ClassroomApi
       response = http.request(request)
       response_json = JSON.parse(response.read_body)
 
-      if response.code == "200"
+      if response.code == OK_CODE
         result['success'] = true
         result['data'] = response_json['Classrooms']
       elsif response_json['errorCode'].present?

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -42,7 +42,7 @@ class ClassroomApi
               redo_loop_number += 1
               redo
             elsif result['success'] 
-              if result['data']['Classroom'][0].present?
+              if result['data']['Classroom'].present?
                 room_info = result['data']['Classroom'][0]
                 rmrecnbr = room_info['RmRecNbr'].to_i
                 room_in_db = Room.find_by(rmrecnbr: rmrecnbr)

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -1,5 +1,7 @@
 class ClassroomApi
 
+  ERR429 = "ERR429"
+
   def initialize(access_token)
     @buildings_ids = Building.all.pluck(:bldrecnbr)
     @access_token = access_token
@@ -28,7 +30,7 @@ class ClassroomApi
             facility_id = room['FacilityID'].to_s
             # add facility_id and number of seats
             result = get_classroom_info(ERB::Util.url_encode(facility_id))
-            if result['errorcode'] == "ERR429"
+            if result['errorcode'] == ERR429
               @log.api_logger.debug "add_facility_id_to_classrooms, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
               number_of_api_calls_per_minutes = 0
               sleep(61.seconds)
@@ -185,7 +187,7 @@ class ClassroomApi
         facility_id = room.facility_code_heprod
         rmrecnbr = room.rmrecnbr
         result = get_classroom_characteristics(ERB::Util.url_encode(facility_id))
-        if result['errorcode'] == "ERR429"
+        if result['errorcode'] == ERR429
           @log.api_logger.debug "update_all_classroom_characteristics, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
           number_of_api_calls_per_minutes = 0
           sleep(61.seconds)
@@ -313,7 +315,7 @@ class ClassroomApi
         facility_id = room.facility_code_heprod
         rmrecnbr = room.rmrecnbr
         result = get_classroom_contact(ERB::Util.url_encode(facility_id))
-        if result['errorcode'] == "ERR429"
+        if result['errorcode'] == ERR429
           @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{result['errorcode']} - #{result['error']} after #{number_of_api_calls_per_minutes} calls"
           number_of_api_calls_per_minutes = 0
           sleep(61.seconds)

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -346,7 +346,7 @@ class ClassroomApi
       end
     rescue StandardError => e
       # example: Errno::ETIMEDOUT: Operation timed out - user specified timeout
-      @log.api_logger.debug "update_rooms, error: API return: #{e.message}"
+      @log.api_logger.debug "update_all_classroom_contacts, error: API return: #{e.message}"
       @debug = true
     end
     return @debug

--- a/lib/classroom_api.rb
+++ b/lib/classroom_api.rb
@@ -199,8 +199,8 @@ class ClassroomApi
           redo_loop_number += 1
           redo
         elsif result['success']
-          if result['data']['Classroom'].present?
-            characteristics = result['data']['Classroom']
+          characteristics = result['data']['Classroom']
+          if characteristics.present?
             if RoomCharacteristic.where(rmrecnbr: rmrecnbr).present?
               db_chrstc_list = RoomCharacteristic.where(rmrecnbr: rmrecnbr).pluck(:chrstc)
               characteristics.each do |c|
@@ -329,7 +329,6 @@ class ClassroomApi
         elsif result['success']
           if result['data']['Classroom'].present?
             row = result['data']['Classroom'][0]
-            
             if RoomContact.find_by(rmrecnbr: rmrecnbr).present?
               update_classroom_contact(row, rmrecnbr)
             else


### PR DESCRIPTION
Here are [migration steps](https://dir.api.it.umich.edu/guides/migration-to-denodo/classrooms)

Migration steps include:

- base URL includes v2 keyword
- response format changed for /Classrooms/{RoomID}/Characteristics
- pagination was added: [Introducing Pagination](https://dir.api.it.umich.edu/guides/migration-to-denodo )

I added pagination only to the get_classrooms_list method because other API requests would never return more than 1000 records (by default the number of results in one API call is limited to 1000 records).

Added _rescue StandardError => e_ to API requests and methods that call those requests.

Also, I edited the api_status helper method to find all records about the api_update_database result if it runs more than once a day. Currently, it selects the first record only.