### PR TITLE
Add University Standard Practice Guide Policy 601.41 to footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -15,6 +15,9 @@
     <div class='flex justify-center tracking-tighter'>
       Copyright <%= Time.now.year %> | <%= link_to 'The Regents of the University of Michigan', 'https://regents.umich.edu', class: 'pl-1 text-blue-800 hover:underline' %>
     </div>
+    <div class='flex justify-center tracking-tighter'>
+      By agreeing to the use of University of Michigan Facilities, you agree to abide by <a class="pl-1 text-blue-800 hover:underline" href="https://spg.umich.edu/policy/601.41">University Standard Practice Guide Policy 601.41.</a>
+    </div>
   </div>
   
   <script type="text/javascript" src="https://umlsait.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/r5gghz/b/3/bc54840da492f9ca037209037ef0522a/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=51ecac03"></script>


### PR DESCRIPTION
This commit adds a new line to the footer of the website, displaying a link to the University Standard Practice Guide Policy 601.41. This ensures that users are aware of and agree to abide by the policy when using University of Michigan Facilities.