### PR TITLE
Bug Fix: LRA-1034 MClassrooms Display All Characteristics in Filters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
     # create array of room cahracteristics to use in filters
     characteristics_all = RoomCharacteristic.all.pluck(:chrstc_descr, :chrstc_descrshort).uniq
     characteristics_all.delete_if {|x| x.include?(nil)}
-    characteristics_all.sort
+    characteristics_all = characteristics_all.sort
     @all_characteristics_array = {}
     category_prev = ""
     other = {}


### PR DESCRIPTION
Since the characteristics_all array was not edited after sorting not all characteristics were moved to the  @all_characteristics_array which is used to display checkbox filters on the Find a Room page.
