### PR TITLE
Refactor mobile menu dropdown for improved accessibility and code clarity

### DIFF
--- a/app/views/layouts/_headness_mobile_menu_dropdown.html.erb
+++ b/app/views/layouts/_headness_mobile_menu_dropdown.html.erb
@@ -1,9 +1,9 @@
-<div class="flex items-center sm:hidden">  
-  <div id="mobile-menu" aria-labelledby="header-nav-menu-button" aria-orientation="vertical" 
-        data-dropdown-entering-class="transition ease-out duration-200" 
-        data-dropdown-invisible-class="opacity-0 -translate-y-1 scale-95" 
-        data-dropdown-leaving-class="transition ease-in duration-150" 
-        data-dropdown-target="menu" data-dropdown-visible-class="opacity-100  -translate-y-0" 
+<div class="flex items-center sm:hidden">
+  <div id="mobile-menu" aria-labelledby="header-nav-menu-button" aria-orientation="vertical"
+        data-dropdown-entering-class="transition ease-out duration-200"
+        data-dropdown-invisible-class="opacity-0 -translate-y-1 scale-95"
+        data-dropdown-leaving-class="transition ease-in duration-150"
+        data-dropdown-target="menu" data-dropdown-visible-class="opacity-100  -translate-y-0"
          tabindex="-1">
     <div class="pt-2 pb-3 space-y-1 text-white" id="header-nav-menu-button">
       <%= link_to "Find a Room", rooms_path, class: "mobile-dropdown-link #{class_names(active: current_page?(rooms_path))} " if user_signed_in? %>
@@ -17,7 +17,7 @@
             <div class="leading-tight text-md font-medium text-white">
               <%= current_user.email %>
             </div>
-            <%= button_to destroy_user_session_path, method: :delete, role: "menuitem", tabindex: "-1", data: {turbo: "false"} do  %>
+            <%= button_to destroy_user_session_path, method: :delete, role: "menuitem", data: {turbo: "false"} do  %>
               <div class="w-60 py-3 shadow-sm font-medium rounded text-blue-900 bg-yellow-550 hover:bg-yellow-500 hover:underline">Sign Out</div>
             <% end %>
           <% else %>


### PR DESCRIPTION
- Removed unnecessary tabindex from the sign-out button to streamline the markup.