### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# MClassrooms
+
+Ruby on Rails 8.1 application for University of Michigan classroom management/directory.
+
+## Cursor Cloud specific instructions
+
+### Runtime versions
+
+Managed via `mise` (reads `.tool-versions`): Ruby 3.4.7, Node.js 20.19.6. After VM startup, `mise install` is run automatically via the update script.
+
+### Services
+
+| Service | How to start | Notes |
+|---|---|---|
+| PostgreSQL | `pg_ctlcluster 16 main start` | Must be running before Rails. Three databases per env (primary, queue, cable). |
+| Rails + Tailwind + Jobs | `bin/dev` | Uses foreman; runs Puma on port 3000, Tailwind CSS watcher, and Solid Queue worker. |
+
+### Key commands
+
+- **Lint:** `bundle exec standardrb` (Ruby Standard Style). Exit code 1 = style warnings (13 pre-existing); use `--fix` to auto-fix.
+- **Security:** `bundle exec brakeman` (1 pre-existing weak warning).
+- **Tests:** `bundle exec rspec` (181 specs).
+- **DB prepare:** `bin/rails db:prepare` (creates all 3 databases + loads `db/structure.sql`).
+- **DB seed:** `bin/rails db:seed` (creates Announcement records).
+- **Dev server:** `bin/dev` (foreman: web + css + jobs).
+
+### Test login (non-production)
+
+Set env vars to enable a bypass login in development:
+
+```
+ENABLE_TEST_LOGIN=true TEST_LOGIN_TOKEN=testtoken123 TEST_LOGIN_EMAIL=test@umich.edu bin/dev
+```
+
+Then visit `http://localhost:3000/test_login?token=testtoken123` to log in. Defaults to admin role.
+
+### Gotchas
+
+- The app uses `config.active_record.schema_format = :sql`, so migrations produce `db/structure.sql` (not `schema.rb`). When running `db:prepare` on a fresh database it loads this SQL file automatically.
+- `bundle exec standardrb` currently has 13 pre-existing style offenses. Do not attempt to fix them unless explicitly asked.
+- `brakeman` exits with code 3 (warnings present) due to 1 pre-existing HTTP Verb Confusion warning. This is expected.
+- Tailwind CSS watcher logs `sh: 1: watchman: not found` — this is harmless; it falls back to polling.
+- No Redis required. Solid Queue and Solid Cable both use PostgreSQL.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What's included

- Runtime version info (Ruby 3.4.7, Node.js 20.19.6 via mise)
- Service startup table (PostgreSQL, Rails dev server)
- Key commands for lint, tests, security scanning, DB setup
- Test login instructions for non-production environments
- Known gotchas (SQL schema format, pre-existing lint warnings, Tailwind watchman fallback)

## Verification

All development tasks verified working:

- **Lint:** `bundle exec standardrb` runs (13 pre-existing warnings)
- **Security:** `bundle exec brakeman` runs (1 pre-existing weak warning)
- **Tests:** `bundle exec rspec` — 181 examples, 0 failures
- **Dev server:** `bin/dev` starts Puma on port 3000, Tailwind watcher, and Solid Queue
- **Test login:** `/test_login?token=testtoken123` authenticates successfully

### Demo

[mclassrooms_demo_walkthrough.mp4](https://cursor.com/agents/bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmclassrooms_demo_walkthrough.mp4)

[MClassrooms homepage](https://cursor.com/agents/bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Logged in as test user](https://cursor.com/agents/bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogged_in.webp)
[Buildings page](https://cursor.com/agents/bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuildings_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1321c38-5607-4cc6-b89c-dab7a2c8dd75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

