### PR TITLE
Refactor CI workflow and error handling for improved testing

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -23,7 +23,7 @@ class AnnouncementsController < ApplicationController
     if @announcement.save
       redirect_to announcements_path, notice: "Announcement was successfully created."
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class AnnouncementsController < ApplicationController
     if @announcement.update(announcement_params)
       redirect_to announcements_path, notice: "Announcement was successfully updated."
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -46,7 +46,7 @@ class BuildingsController < ApplicationController
         format.json { render :show, status: :ok, location: @building }
       else
         format.html { redirect_to @building, alert: @building.errors.full_messages }
-        format.json { render json: @building.errors, status: :unprocessable_entity }
+        format.json { render json: @building.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,7 +6,7 @@ class NotesController < ApplicationController
     if @note.update(note_params) && @note.update(user: current_user)
       redirect_to @note
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -108,13 +108,13 @@ class RoomsController < ApplicationController
         rescue ActiveStorage::FileNotFoundError => e
           Rails.logger.error "Failed to process image: #{e.message}"
           format.html { redirect_to @room, notice: "Room was updated but image processing failed." }
-          format.json { render json: {error: "Image processing failed"}, status: :unprocessable_entity }
+          format.json { render json: {error: "Image processing failed"}, status: :unprocessable_content }
         end
       else
         flash.now[:alert] = @room.errors.full_messages.to_sentence
-        format.html { render :edit, status: :unprocessable_entity }
-        format.turbo_stream { render :edit, status: :unprocessable_entity, formats: [:html] }
-        format.json { render json: @room.errors, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_content }
+        format.turbo_stream { render :edit, status: :unprocessable_content, formats: [:html] }
+        format.json { render json: @room.errors, status: :unprocessable_content }
       end
     end
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -349,7 +349,7 @@ Devise.setup do |config|
   # Devise 4.9+ requires this for proper Turbo integration.
   # When using Devise with Hotwire/Turbo, the following needs to be set to handle
   # form errors appropriately with the 422 Unprocessable Entity status code.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable

--- a/spec/lib/flash_errors_helper_spec.rb
+++ b/spec/lib/flash_errors_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe FlashErrorsHelper, type: :helper do
+  describe "#flash_class" do
+    it "maps known severities to css classes" do
+      expect(helper.flash_class(:alert)).to eq("alert-danger")
+      expect(helper.flash_class(:error)).to eq("alert-error")
+      expect(helper.flash_class(:notice)).to eq("alert-notice")
+      expect(helper.flash_class(:success)).to eq("alert-success")
+      expect(helper.flash_class(:warning)).to eq("alert-warning")
+    end
+  end
+
+  describe "#severity_icon" do
+    it "returns configured icons" do
+      expect(helper.severity_icon(:danger)).to eq("shield-exclamation")
+      expect(helper.severity_icon(:notice)).to eq("circle-check")
+      expect(helper.severity_icon(:warning)).to eq("siren-on")
+    end
+  end
+end

--- a/spec/lib/room_characteristic_decorator_spec.rb
+++ b/spec/lib/room_characteristic_decorator_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe RoomCharacteristicDecorator do
+  describe "#characteristic_icon" do
+    it "returns an icon class for known short descriptions" do
+      characteristic = RoomCharacteristic.new(chrstc_descrshort: "ProjDigit")
+      decorator = described_class.decorate(characteristic)
+
+      expect(decorator.characteristic_icon).to eq("fas fa-video")
+    end
+  end
+
+  describe "#characteristic_label" do
+    it "normalizes known prefixes" do
+      board = described_class.decorate(RoomCharacteristic.new(chrstc_descr: "Board:Whiteboard"))
+      ethernet = described_class.decorate(RoomCharacteristic.new(chrstc_descr: "Ethernet Connection:Wired"))
+      blank = described_class.decorate(RoomCharacteristic.new(chrstc_descr: nil))
+
+      expect(board.characteristic_label).to eq("Whiteboard")
+      expect(ethernet.characteristic_label).to eq("Ethernet:Wired")
+      expect(blank.characteristic_label).to eq("missing")
+    end
+
+    it "returns original text when no prefix rule matches" do
+      characteristic = described_class.decorate(RoomCharacteristic.new(chrstc_descr: "General Feature"))
+
+      expect(characteristic.characteristic_label).to eq("General Feature")
+    end
+  end
+end

--- a/spec/lib/room_decorator_spec.rb
+++ b/spec/lib/room_decorator_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe RoomDecorator do
+  let(:building) do
+    create(:building, name: "mason hall", address: "419 state street", city: "ann arbor")
+  end
+  let(:room) do
+    create(
+      :room,
+      building_bldrecnbr: building.bldrecnbr,
+      room_number: "1400",
+      instructional_seating_count: 120
+    )
+  end
+  let(:decorator) { described_class.decorate(room) }
+
+  describe "#title" do
+    it "includes room number and titleized building name" do
+      expect(decorator.title).to eq("1400 Mason Hall")
+    end
+  end
+
+  describe "#address" do
+    it "formats a titleized address string" do
+      expect(decorator.address).to include("419 State Street, Ann Arbor")
+    end
+  end
+
+  describe "#student_capacity" do
+    it "pluralizes student count" do
+      expect(decorator.student_capacity).to eq("120 Students")
+    end
+  end
+
+  describe "contact fields" do
+    it "returns fallback values when contact data is absent" do
+      expect(decorator.room_schedule_contact).to eq("Contact Not Available")
+      expect(decorator.room_schedule_email).to eq("Not Available")
+      expect(decorator.room_schedule_phone).to eq("Not Available")
+      expect(decorator.room_support_email).to eq("Not Available")
+      expect(decorator.room_support_phone).to eq("Not Available")
+      expect(decorator.room_support_url).to eq("Not Available")
+    end
+
+    it "returns normalized values when contact data exists" do
+      RoomContact.create!(
+        rmrecnbr: room.rmrecnbr,
+        rm_schd_cntct_name: "jane doe",
+        rm_schd_email: "JDOE@UMICH.EDU",
+        rm_schd_cntct_phone: "734-555-1111",
+        rm_sppt_cntct_email: "help@umich.edu",
+        rm_sppt_cntct_phone: "734-555-2222",
+        rm_sppt_cntct_url: "https://support.umich.edu"
+      )
+
+      expect(decorator.room_schedule_contact).to eq("Jane Doe")
+      expect(decorator.room_schedule_email).to eq("jdoe@umich.edu")
+      expect(decorator.room_schedule_phone).to eq("734-555-1111")
+      expect(decorator.room_support_email).to eq("help@umich.edu")
+      expect(decorator.room_support_phone).to eq("734-555-2222")
+      expect(decorator.room_support_url).to eq("https://support.umich.edu")
+    end
+  end
+end

--- a/spec/lib/search_helper_spec.rb
+++ b/spec/lib/search_helper_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe SearchHelper, type: :helper do
+  describe "#capacity_slider_minimum" do
+    it "defaults to 1 without params" do
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new)
+
+      expect(helper.capacity_slider_minimum).to eq(1)
+    end
+
+    it "uses min_capacity param when present" do
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new(min_capacity: "45"))
+
+      expect(helper.capacity_slider_minimum).to eq("45")
+    end
+  end
+
+  describe "#capacity_slider_maximum" do
+    it "defaults to 600 without building filter" do
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new)
+
+      expect(helper.capacity_slider_maximum).to eq(600)
+    end
+
+    it "uses max_capacity when building_name is present" do
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new(building_name: "Chem", max_capacity: "120"))
+
+      expect(helper.capacity_slider_maximum).to eq("120")
+    end
+  end
+
+  describe "#room_characteristic_icon" do
+    it "returns mapped icon and defaults when unknown" do
+      mapped = RoomCharacteristic.new(chrstc_descrshort: "ProjDigit")
+      unknown = RoomCharacteristic.new(chrstc_descrshort: "UnknownCode")
+
+      expect(helper.room_characteristic_icon(mapped)).to eq("video")
+      expect(helper.room_characteristic_icon(unknown)).to eq("info-circle")
+    end
+  end
+end

--- a/spec/models/omni_auth_service_spec.rb
+++ b/spec/models/omni_auth_service_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe OmniAuthService, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "scopes" do
+    it "filters saml providers" do
+      user = create(:user)
+      saml = user.omni_auth_services.create!(provider: "saml", uid: "saml-user")
+      user.omni_auth_services.create!(provider: "google_oauth2", uid: "google-user")
+
+      expect(described_class.saml).to include(saml)
+      expect(described_class.saml.pluck(:provider).uniq).to eq(["saml"])
+    end
+  end
+
+  describe "#expired?" do
+    it "is true when expires_at is in the past" do
+      service = described_class.new(expires_at: 1.minute.ago)
+
+      expect(service.expired?).to be(true)
+    end
+
+    it "is false when expires_at is nil or in the future" do
+      expect(described_class.new(expires_at: nil).expired?).to be(false)
+      expect(described_class.new(expires_at: 1.minute.from_now).expired?).to be(false)
+    end
+  end
+
+  describe "#client" do
+    it "dispatches to the provider specific client method name" do
+      service = described_class.new(provider: "saml")
+
+      expect { service.client }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe "#access_token" do
+    it "returns access token when not expired" do
+      service = described_class.new(provider: "saml", access_token: "current-token", expires_at: 1.minute.from_now)
+
+      expect(service.access_token).to eq("current-token")
+    end
+
+    it "attempts provider refresh path when expired" do
+      service = described_class.new(provider: "saml", access_token: "old-token", expires_at: 1.minute.ago)
+
+      expect { service.access_token }.to raise_error(NoMethodError)
+    end
+  end
+end

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe AnnouncementPolicy do
+  subject(:policy) { described_class.new(user, announcement) }
+
+  let(:announcement) { Announcement.new(location: "home_page") }
+
+  describe "viewer access" do
+    let(:user) do
+      build_stubbed(:user).tap do |viewer|
+        viewer.membership = ["mi-classrooms-non-admin-staging"]
+        viewer.admin = false
+      end
+    end
+
+    it "denies all announcement management actions" do
+      expect(policy.index?).to be(false)
+      expect(policy.show?).to be(false)
+      expect(policy.create?).to be(false)
+      expect(policy.update?).to be(false)
+      expect(policy.destroy?).to be(false)
+    end
+  end
+
+  describe "admin access" do
+    let(:user) do
+      build_stubbed(:user).tap do |admin|
+        admin.membership = ["mi-classrooms-admin-staging"]
+        admin.admin = true
+      end
+    end
+
+    it "allows all announcement management actions" do
+      expect(policy.index?).to be(true)
+      expect(policy.show?).to be(true)
+      expect(policy.create?).to be(true)
+      expect(policy.update?).to be(true)
+      expect(policy.destroy?).to be(true)
+    end
+  end
+end

--- a/spec/policies/classroom_policy_spec.rb
+++ b/spec/policies/classroom_policy_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe ClassroomPolicy do
+  subject(:policy) { described_class.new(user, :classroom) }
+
+  let(:user) do
+    build_stubbed(:user).tap do |viewer|
+      viewer.membership = ["mi-classrooms-non-admin-staging"]
+      viewer.admin = false
+    end
+  end
+
+  it "allows legacy classroom redirects for all authenticated users" do
+    expect(policy.index?).to be(true)
+    expect(policy.show?).to be(true)
+  end
+end

--- a/spec/policies/page_policy_spec.rb
+++ b/spec/policies/page_policy_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe PagePolicy do
+  subject(:policy) { described_class.new(user, :page) }
+
+  let(:user) do
+    build_stubbed(:user).tap do |viewer|
+      viewer.membership = ["mi-classrooms-non-admin-staging"]
+      viewer.admin = false
+    end
+  end
+
+  it "allows public page actions" do
+    expect(policy.index?).to be(true)
+    expect(policy.about?).to be(true)
+    expect(policy.room_filters_glossary?).to be(true)
+    expect(policy.contact?).to be(true)
+    expect(policy.privacy?).to be(true)
+    expect(policy.project_status?).to be(true)
+  end
+end

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Announcements", type: :request do
         }
       }.not_to change(Announcement, :count)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
 
     it "updates an announcement" do
@@ -112,7 +112,7 @@ RSpec.describe "Announcements", type: :request do
         }
       }
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(announcement.reload.location).to eq("home_page")
     end
 

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -1,0 +1,159 @@
+require "rails_helper"
+
+RSpec.describe "Announcements", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  def force_membership(admin:)
+    allow_any_instance_of(ApplicationController).to receive(:set_membership) do |controller|
+      next unless controller.current_user
+
+      controller.current_user.membership = [admin ? "mi-classrooms-admin-staging" : "mi-classrooms-non-admin-staging"]
+      controller.current_user.admin = admin
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:view_stubs) do
+    lambda do
+      allow_any_instance_of(ActionView::Base).to receive(:stylesheet_link_tag).and_return("")
+      allow_any_instance_of(Importmap::ImportmapTagsHelper).to receive(:javascript_importmap_tags).and_return("")
+      allow_any_instance_of(ActionView::Base).to receive(:image_tag).and_return("")
+      allow_any_instance_of(ApplicationHelper).to receive(:svg).and_return("")
+      allow_any_instance_of(ApplicationHelper).to receive(:room_thumbnail_image).and_return("")
+      allow_any_instance_of(ActionView::Base).to receive(:render).and_wrap_original do |method, *args, **kwargs, &block|
+        partial = args.first
+        next "" if partial == "layouts/header" || partial == "layouts/footer"
+
+        method.call(*args, **kwargs, &block)
+      end
+    end
+  end
+
+  describe "authentication" do
+    it "requires sign in" do
+      get announcements_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "admin access" do
+    let!(:announcement) { Announcement.create!(location: "home_page", content: "Original content") }
+
+    before do
+      sign_in user, scope: :user
+      force_membership(admin: true)
+      view_stubs.call
+    end
+
+    it "loads index" do
+      get announcements_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Announcements")
+    end
+
+    it "loads show" do
+      get announcement_path(announcement)
+
+      expect(response).to have_http_status(:not_acceptable)
+    end
+
+    it "loads new with a preselected location" do
+      get new_announcement_path, params: {location: "about_page"}
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "creates a valid announcement" do
+      expect {
+        post announcements_path, params: {
+          announcement: {
+            location: "about_page",
+            content: "New message"
+          }
+        }
+      }.to change(Announcement, :count).by(1)
+
+      expect(response).to redirect_to(announcements_path)
+      expect(flash[:notice]).to eq("Announcement was successfully created.")
+    end
+
+    it "rejects invalid creates" do
+      expect {
+        post announcements_path, params: {
+          announcement: {
+            location: "",
+            content: "Invalid"
+          }
+        }
+      }.not_to change(Announcement, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "updates an announcement" do
+      patch announcement_path(announcement), params: {
+        announcement: {
+          location: "about_page",
+          content: "Updated content"
+        }
+      }
+
+      expect(response).to redirect_to(announcements_path)
+      expect(flash[:notice]).to eq("Announcement was successfully updated.")
+      expect(announcement.reload.location).to eq("about_page")
+    end
+
+    it "rejects invalid updates" do
+      patch announcement_path(announcement), params: {
+        announcement: {
+          location: "invalid_location"
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(announcement.reload.location).to eq("home_page")
+    end
+
+    it "deletes an announcement" do
+      expect {
+        delete announcement_path(announcement)
+      }.to change(Announcement, :count).by(-1)
+
+      expect(response).to redirect_to(announcements_path)
+      expect(flash[:notice]).to eq("Announcement was successfully deleted.")
+    end
+  end
+
+  describe "viewer access" do
+    let!(:announcement) { Announcement.create!(location: "home_page", content: "Visible content") }
+
+    before do
+      sign_in user, scope: :user
+      force_membership(admin: false)
+      view_stubs.call
+    end
+
+    it "denies index" do
+      get announcements_path
+
+      expect(response).to redirect_to(about_path)
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "denies show" do
+      get announcement_path(announcement)
+
+      expect(response).to redirect_to(about_path)
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "denies create" do
+      post announcements_path, params: {announcement: {location: "about_page", content: "No access"}}
+
+      expect(response).to redirect_to(about_path)
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Pages", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  def stub_layout_dependencies
+    allow_any_instance_of(ActionView::Base).to receive(:stylesheet_link_tag).and_return("")
+    allow_any_instance_of(Importmap::ImportmapTagsHelper).to receive(:javascript_importmap_tags).and_return("")
+    allow_any_instance_of(ActionView::Base).to receive(:image_tag).and_return("")
+    allow_any_instance_of(ApplicationHelper).to receive(:svg).and_return("")
+    allow_any_instance_of(ApplicationHelper).to receive(:room_thumbnail_image).and_return("")
+    allow_any_instance_of(ActionView::Base).to receive(:render).and_wrap_original do |method, *args, **kwargs, &block|
+      partial = args.first
+      next "" if partial == "layouts/header" || partial == "layouts/footer"
+
+      method.call(*args, **kwargs, &block)
+    end
+  end
+
+  def force_membership(admin:)
+    allow_any_instance_of(ApplicationController).to receive(:set_membership) do |controller|
+      next unless controller.current_user
+
+      controller.current_user.membership = [admin ? "mi-classrooms-admin-staging" : "mi-classrooms-non-admin-staging"]
+      controller.current_user.admin = admin
+    end
+  end
+
+  let(:user) { create(:user) }
+
+  before do
+    stub_layout_dependencies
+  end
+
+  describe "GET /" do
+    it "loads home for guests" do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "redirects signed-in viewers to rooms" do
+      sign_in user, scope: :user
+      force_membership(admin: false)
+
+      get root_path
+
+      expect(response).to redirect_to(rooms_path)
+    end
+  end
+
+  describe "GET /about" do
+    it "loads the about page" do
+      get about_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /room_filters_glossary" do
+    before do
+      building = create(:building)
+      room = create(:room, building_bldrecnbr: building.bldrecnbr)
+      create(:room_characteristic, rmrecnbr: room.rmrecnbr, chrstc_descrshort: "Projector", chrstc_desc254: "Projection display")
+      create(:room_characteristic, rmrecnbr: room.rmrecnbr, chrstc_descrshort: "Whiteboard", chrstc_desc254: "Wall whiteboard")
+    end
+
+    it "requires authentication" do
+      get room_filters_glossary_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "allows authenticated users" do
+      sign_in user, scope: :user
+      force_membership(admin: false)
+
+      get room_filters_glossary_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "Users::OmniauthCallbacks", type: :request do
+  def set_auth_hash(email:, uid: email, provider: "saml")
+    OmniAuth.config.mock_auth[:saml] = OmniAuth::AuthHash.new(
+      provider: provider,
+      uid: uid,
+      info: {
+        email: email,
+        uid: uid,
+        principal_name: email,
+        name: "Test User",
+        person_affiliation: "staff"
+      }
+    )
+  end
+
+  def stub_group_membership(admin:)
+    allow(LdapLookup).to receive(:is_member_of_group?) do |uniqname, group|
+      expect(uniqname).to eq("callbackuser")
+      if admin
+        group == "mi-classrooms-admin-staging"
+      else
+        group == "mi-classrooms-non-admin-staging"
+      end
+    end
+  end
+
+  describe "POST /users/auth/saml/callback" do
+    before do
+      OmniAuth.config.test_mode = true
+    end
+
+    after do
+      OmniAuth.config.mock_auth[:saml] = nil
+      OmniAuth.config.test_mode = false
+    end
+
+    it "creates a user session and membership data for admin users" do
+      set_auth_hash(email: "callbackuser@umich.edu")
+      stub_group_membership(admin: true)
+
+      post user_saml_omniauth_callback_path
+
+      expect(response).to redirect_to(root_path)
+      user = User.find_by(email: "callbackuser@umich.edu")
+      expect(user).to be_present
+      expect(user.uniqname).to eq("callbackuser")
+      expect(user.omni_auth_services.where(provider: "saml").exists?).to be(true)
+    end
+
+    it "reuses and updates an existing omni auth service" do
+      user = create(:user, email: "callbackuser@umich.edu", uniqname: "callbackuser")
+      service = user.omni_auth_services.create!(provider: "saml", uid: "callbackuser@umich.edu")
+      set_auth_hash(email: "callbackuser@umich.edu", uid: "callbackuser@umich.edu")
+      stub_group_membership(admin: false)
+
+      post user_saml_omniauth_callback_path
+
+      expect(response).to redirect_to(root_path)
+      expect(user.omni_auth_services.count).to eq(1)
+      expect(service.reload.provider).to eq("saml")
+      expect(service.uid).to eq("callbackuser@umich.edu")
+
+      get buildings_path(format: :json)
+      expect(response).to redirect_to(about_path)
+      expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+    end
+
+    it "redirects to sign in when ldap lookup fails" do
+      set_auth_hash(email: "callbackuser@umich.edu")
+      allow(LdapLookup).to receive(:is_member_of_group?).and_raise(Net::LDAP::Error.new("ldap down"))
+
+      post user_saml_omniauth_callback_path
+
+      expect(response).to redirect_to(new_user_session_path)
+      expect(flash[:alert]).to eq("Authentication failed due to a temporary issue. Please try again later or contact support.")
+    end
+
+    it "redirects to sign in when auth payload is missing email" do
+      OmniAuth.config.mock_auth[:saml] = OmniAuth::AuthHash.new(provider: "saml", uid: "missing-email", info: {})
+
+      post user_saml_omniauth_callback_path
+
+      expect(response).to redirect_to(new_user_session_path)
+      expect(flash[:alert]).to eq("Authentication failed.")
+    end
+
+    it "redirects through omniauth failure handling" do
+      OmniAuth.config.mock_auth[:saml] = :invalid_credentials
+      post user_saml_omniauth_callback_path
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq("Authentication failed.")
+    end
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe "Users::OmniauthCallbacks", type: :request do
   def stub_group_membership(admin:)
     allow(LdapLookup).to receive(:is_member_of_group?) do |uniqname, group|
       expect(uniqname).to eq("callbackuser")
-      if admin
-        group == "mi-classrooms-admin-staging"
+      group == if admin
+        "mi-classrooms-admin-staging"
       else
-        group == "mi-classrooms-non-admin-staging"
+        "mi-classrooms-non-admin-staging"
       end
     end
   end


### PR DESCRIPTION
This pull request introduces two main types of changes: (1) standardizing the HTTP status code for unprocessable requests throughout the application from `:unprocessable_entity` to `:unprocessable_content`, and (2) adding comprehensive RSpec test coverage for helpers, decorators, policies, models, and controller/request flows. These updates improve both the consistency of error handling and the reliability of the codebase through enhanced testing.

**Error handling standardization:**

* Replaced all instances of `:unprocessable_entity` with `:unprocessable_content` in controller actions and in the Devise initializer for error responses, ensuring uniform error status handling across the app. [[1]](diffhunk://#diff-fbd834070d3fabf3b7ada1c2915bc24d13021fc5a79dd48f2cbf0ea5f78d2045L26-R26) [[2]](diffhunk://#diff-fbd834070d3fabf3b7ada1c2915bc24d13021fc5a79dd48f2cbf0ea5f78d2045L37-R37) [[3]](diffhunk://#diff-df9818227e4e11ffba4e438de12320d957e2d01d5ffb3f4667e278a074861badL49-R49) [[4]](diffhunk://#diff-c254740097a8c0601832077488db77e572b2c2b926f77508fadc6081b0052804L9-R9) [[5]](diffhunk://#diff-16e9830311185de1ace2bb01b491a8e704f74aaebeeab2a0d21a72cb090f261eL111-R117) [[6]](diffhunk://#diff-cb6e8126296dbc007e7625eee863de5c3213ed949b9999ea3418775f65826531L352-R352)

**Test suite expansion:**

_Helper and decorator specs:_
* Added RSpec tests for `FlashErrorsHelper`, `RoomCharacteristicDecorator`, `RoomDecorator`, and `SearchHelper`, verifying correct mapping, normalization, and formatting behaviors. [[1]](diffhunk://#diff-9aa8831ccbb8a6830d29fad5b621c9966a2aa31ee5a46c51ffde603353e9bdf7R1-R21) [[2]](diffhunk://#diff-66ecf22742645147ab57eca879a21407b0626a66ea4e74d1be59eb4f26b6b9ecR1-R30) [[3]](diffhunk://#diff-38f647ad204fb021a9dcccbc6810601614649e39be5cb0a97b9671a0b687b4fdR1-R64) [[4]](diffhunk://#diff-6941c39eafa65f7b981689c09a4be38bf90cc1a82bd0684b9e3dcc93901609daR1-R41)

_Model and policy specs:_
* Added model spec for `OmniAuthService`, testing associations, scopes, expiration logic, and token handling.
* Added policy specs for `AnnouncementPolicy`, `ClassroomPolicy`, and `PagePolicy`, ensuring correct authorization logic for different user roles. [[1]](diffhunk://#diff-1b872fae8e62505e1d78ccabca91e70dfe5b8581130d1282a38d7a1e478c679aR1-R41) [[2]](diffhunk://#diff-2a30a92bfd5ade44e863f38c93a21dd6f64b7223be97670716f1d82786cf1511R1-R17) [[3]](diffhunk://#diff-a99000bd6951b27247454c1ca5c2f02020ff8d8484f98e477a2e0f44eae607edR1-R21)

_Request specs:_
* Added request specs for announcements and pages, covering authentication, authorization, CRUD actions, and layout dependencies. [[1]](diffhunk://#diff-0c00b33fd3fac1c06cb5a8016d3d8da41ed005ffd2b2dd3001bea0b68ab6a2afR1-R159) [[2]](diffhunk://#diff-def24c0c177d3f5d7932a349c8120457c29960f86a8228fe63ce60e8e8834cb5R1-R83)