### PR TITLE
Update devise to 5.0.4 and enhance README for Siteimprove integration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Ruby)
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reduce CodeQL action download contention
+        shell: bash
+        run: |
+          sleep $((RANDOM % 60))
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.35.4
+        with:
+          languages: ruby
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.7"
+          bundler-cache: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvips libvips-tools
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4.35.4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4.35.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
     date (3.5.1)
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)
@@ -198,7 +198,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.4)
+    json (2.19.5)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -232,7 +232,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     mission_control-jobs (1.1.0)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 - omniauth-SAML
 - ldap_lookup used to gather user information (especially group affiliation for authorization)
 
-### Non-production test login
+### Non-production test login (not available in production)
 
-When SAML/IdP callback targets are controlled externally (for example, University auth callbacks pointing to another server), you can enable a temporary test login in non-production environments:
+When SAML/IdP callback targets are controlled externally (for example, University auth callbacks pointing to another server), you can enable a **secret URL** on **development, test, or staging** only. The `/test_login` route is not registered when `Rails.env.production?` is true, and the controller rejects those requests, so a true production deploy never exposes this feature. (Use a dedicated environment such as `staging` for Siteimprove; a server that runs `RAILS_ENV=production` against a staging hostname is still treated as production.)
+
+Use a long random `TEST_LOGIN_TOKEN`, store it in a vault, rotate if it leaks, and set `ENABLE_TEST_LOGIN` only when needed.
 
 ```sh
 ENABLE_TEST_LOGIN=true \
@@ -28,7 +30,11 @@ Then visit:
 Optional:
 
 - `TEST_LOGIN_GROUPS=mi-classrooms-admin-staging,mi-classrooms-non-admin-staging` to control role/group behavior.
-- If `TEST_LOGIN_GROUPS` is omitted, the login defaults to admin for the current non-production environment.
+- If `TEST_LOGIN_GROUPS` is omitted, the login defaults to admin for the current non-production environment (`mi-classrooms-admin-staging` in staging).
+
+#### Siteimprove on staging
+
+[Siteimprove](https://help.siteimprove.com/support/solutions/articles/80001162737-the-siteimprove-crawler-bot-information) cannot complete your interactive SSO. Point the crawl at **staging** only: set `ENABLE_TEST_LOGIN` and related variables on the **staging** host, then use a **start URL** such as `https://<staging-host>/test_login?token=<your-secret-token>` so the crawler receives a session cookie after the redirect. Crawler identity and IPs: [What IP addresses and user agents are used by Siteimprove?](https://help.siteimprove.com/support/solutions/articles/80000448553-what-ip-addresses-and-user-agents-are-used-by-siteimprove-). Ensure `robots.txt` does not disallow paths you need crawled; you can allow `SiteimproveBot-Crawler` if you add restrictive rules for other bots.
 
 ## Configuration (production / staging)
 
@@ -48,7 +54,7 @@ Optional environment variables:
 
 ### U-M API HTTPS
 
-`lib/um_api.rb` uses normal TLS verification (`VERIFY_PEER`, minimum TLS 1.2). If token or API calls fail in an environment with a custom CA bundle, set `SSL_CERT_FILE` (or your platform’s equivalent) so OpenSSL can validate `gw.api.it.umich.edu`.
+`lib/um_api.rb` uses normal TLS verification (`VERIFY_PEER`, minimum TLS 1.2). If token or API calls fail in an environment with a custom CA bundle, set `SSL_CERT_FILE` (or your platform's equivalent) so OpenSSL can validate `gw.api.it.umich.edu`.
 
 ### Database loading data
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks", sessions: "users/sessions"} do
     delete "sign_out", to: "users/sessions#destroy", as: :destroy_user_session
   end
-  # Non-production test login endpoint for local/staging validation without IdP callback changes.
+  # Non-production only: token URL for SAML bypass (local/staging), e.g. Siteimprove on staging.
+  # Not registered in production under any configuration.
   unless Rails.env.production?
     get "test_login", to: "users/test_sessions#show", as: :test_login
   end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,9 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# https://www.robotstxt.org/robotstxt.html
+# Siteimprove crawler tokens:
+# https://help.siteimprove.com/support/solutions/articles/80001162737-the-siteimprove-crawler-bot-information
+
+User-agent: SiteimproveBot-Crawler
+Allow: /
+
+User-agent: SiteimproveBot
+Allow: /


### PR DESCRIPTION
This pull request updates documentation and configuration to clarify and support the use of a non-production test login endpoint, particularly for integration with the Siteimprove crawler, and adds explicit robots.txt rules to allow Siteimprove access. The changes emphasize security and environment-specific behavior for the test login feature.

**Test login endpoint and documentation:**

* Updated `README.md` to clarify that the `/test_login` endpoint is only available in non-production environments, never in production, and to recommend secure practices for the `TEST_LOGIN_TOKEN` and `ENABLE_TEST_LOGIN` environment variables.
* Added documentation on using the test login endpoint with Siteimprove in staging, including instructions for configuring the crawler and ensuring robots.txt allows access.
* Updated `config/routes.rb` to reinforce that the `test_login` route is only registered in non-production environments, preventing accidental exposure in production.

**Siteimprove crawler access:**

* Added explicit `robots.txt` rules to allow both `SiteimproveBot-Crawler` and `SiteimproveBot` user agents full access, supporting Siteimprove's crawling of staging environments.

**Minor documentation fix:**

* Standardized wording in the `README.md` regarding TLS verification and custom CA bundles.