### PR TITLE
Refactor test setup to exclude test_seeds.rb from automatic loading

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,14 @@ end
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+# NOTE: test_seeds.rb is intentionally excluded here. It mutates the database at
+# load time (committing rows outside of DatabaseCleaner transactions), so it must
+# only be loaded explicitly by the specs that need it (see system specs).
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each do |f|
+  next if File.basename(f) == "test_seeds.rb"
+
+  require f
+end
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/spec/support/test_seeds.rb
+++ b/spec/support/test_seeds.rb
@@ -1,3 +1,11 @@
+# Make seeding idempotent. This file is `load`ed directly by specs that use the
+# truncation strategy, and may run against a database that still contains rows
+# from a previous load. Clear children before parents to respect foreign keys.
+Room.delete_all
+Building.delete_all
+Announcement.delete_all
+CampusRecord.delete_all
+
 CampusRecord.create([
   {id: 1,
    campus_cd: 100,


### PR DESCRIPTION
- Updated rails_helper.rb to skip loading test_seeds.rb to prevent database mutations during test setup.
- Enhanced test_seeds.rb to ensure idempotent seeding by clearing existing records before creating new ones.